### PR TITLE
Aix llvm flag

### DIFF
--- a/clang/test/SemaCXX/class-layout.cpp
+++ b/clang/test/SemaCXX/class-layout.cpp
@@ -639,7 +639,7 @@ namespace PR37275 {
 #pragma pack(pop)
 }
 
-#endif // !defined(__MVS__) && !defined(__AIX__)
+#endif // !defined(__MVS__) && !defined(_AIX)
 
 namespace non_pod {
 struct t1 {

--- a/lldb/CMakeLists.txt
+++ b/lldb/CMakeLists.txt
@@ -39,7 +39,7 @@ include(LLDBConfig)
 include(AddLLDB)
 
 if (UNIX AND ${CMAKE_SYSTEM_NAME} MATCHES "AIX")
-  add_definitions("-D__AIX__")
+  add_definitions("-D_AIX")
 endif()
 
 # Define the LLDB_CONFIGURATION_xxx matching the build type.

--- a/lldb/CMakeLists.txt
+++ b/lldb/CMakeLists.txt
@@ -38,10 +38,6 @@ endif()
 include(LLDBConfig)
 include(AddLLDB)
 
-if (UNIX AND ${CMAKE_SYSTEM_NAME} MATCHES "AIX")
-  add_definitions("-D_AIX")
-endif()
-
 # Define the LLDB_CONFIGURATION_xxx matching the build type.
 if(uppercase_CMAKE_BUILD_TYPE STREQUAL "DEBUG" )
   add_definitions(-DLLDB_CONFIGURATION_DEBUG)

--- a/lldb/include/lldb/Host/HostGetOpt.h
+++ b/lldb/include/lldb/Host/HostGetOpt.h
@@ -9,7 +9,7 @@
 #ifndef LLDB_HOST_HOSTGETOPT_H
 #define LLDB_HOST_HOSTGETOPT_H
 
-#if !defined(_MSC_VER) && !defined(__NetBSD__) && !defined(__AIX__)
+#if !defined(_MSC_VER) && !defined(__NetBSD__) && !defined(_AIX)
 
 #include <getopt.h>
 #include <unistd.h>

--- a/lldb/include/lldb/Host/HostInfo.h
+++ b/lldb/include/lldb/Host/HostInfo.h
@@ -55,7 +55,7 @@
 #elif defined(__APPLE__)
 #include "lldb/Host/macosx/HostInfoMacOSX.h"
 #define HOST_INFO_TYPE HostInfoMacOSX
-#elif defined(__AIX__)
+#elif defined(_AIX)
 #include "lldb/Host/aix/HostInfoAIX.h"
 #define HOST_INFO_TYPE HostInfoAIX
 #else

--- a/lldb/include/lldb/Host/XML.h
+++ b/lldb/include/lldb/Host/XML.h
@@ -11,7 +11,7 @@
 
 #include "lldb/Host/Config.h"
 
-#if defined(__AIX__)
+#if defined(_AIX)
 //FIXME for AIX
 #undef LLDB_ENABLE_LIBXML2
 #endif

--- a/lldb/include/lldb/Host/common/GetOptInc.h
+++ b/lldb/include/lldb/Host/common/GetOptInc.h
@@ -11,11 +11,11 @@
 
 #include "lldb/lldb-defines.h"
 
-#if defined(_MSC_VER) || defined(__AIX__)
+#if defined(_MSC_VER) || defined(_AIX)
 #define REPLACE_GETOPT
 #define REPLACE_GETOPT_LONG
 #endif
-#if defined(_MSC_VER) || defined(__NetBSD__) || defined(__AIX__)
+#if defined(_MSC_VER) || defined(__NetBSD__) || defined(_AIX)
 #define REPLACE_GETOPT_LONG_ONLY
 #endif
 

--- a/lldb/include/lldb/Target/Process.h
+++ b/lldb/include/lldb/Target/Process.h
@@ -65,7 +65,7 @@
 #include "llvm/Support/Threading.h"
 #include "llvm/Support/VersionTuple.h"
 
-#if defined(__AIX__)
+#if defined(_AIX)
 struct ld_xinfo;
 #endif
 
@@ -1884,7 +1884,7 @@ public:
   Status GetMemoryRegionInfo(lldb::addr_t load_addr,
                              MemoryRegionInfo &range_info);
 
-#if defined(__AIX__)
+#if defined(_AIX)
   Status GetLDXINFO(struct ld_xinfo *info_ptr);
 #endif
 
@@ -2823,7 +2823,7 @@ protected:
         "Process::DoGetMemoryRegionInfo() not supported");
   }
 
-#if defined(__AIX__)
+#if defined(_AIX)
   virtual Status DoGetLDXINFO(struct ld_xinfo *info_ptr) {
     return Status("Process::DoGetLDXINFO() not supported");
   }

--- a/lldb/include/lldb/Target/RegisterContextUnwind.h
+++ b/lldb/include/lldb/Target/RegisterContextUnwind.h
@@ -67,7 +67,7 @@ public:
 
   bool ReadPC(lldb::addr_t &start_pc);
 
-#ifdef __AIX__
+#ifdef _AIX
   bool ReadLR(lldb::addr_t &lr);
 #endif
 

--- a/lldb/source/Core/Mangled.cpp
+++ b/lldb/source/Core/Mangled.cpp
@@ -167,7 +167,7 @@ static char *GetItaniumDemangledStr(const char *M) {
            "Expected demangled_size to return length including trailing null");
   }
 
-#if !defined(__AIX__)  
+#if !defined(_AIX)  
   if (Log *log = GetLog(LLDBLog::Demangle)) {
     if (demangled_cstr)
       LLDB_LOGF(log, "demangled itanium: %s -> \"%s\"", M, demangled_cstr);

--- a/lldb/source/Core/Section.cpp
+++ b/lldb/source/Core/Section.cpp
@@ -263,7 +263,7 @@ bool Section::ResolveContainedAddress(addr_t offset, Address &so_addr,
 
 bool Section::ContainsFileAddress(addr_t vm_addr) const {
   const addr_t file_addr = GetFileAddress();
-#ifdef __AIX__
+#ifdef _AIX
   if (file_addr == 0)
     return false;
 #endif

--- a/lldb/source/Host/common/Host.cpp
+++ b/lldb/source/Host/common/Host.cpp
@@ -358,7 +358,7 @@ bool Host::ResolveExecutableInBundle(FileSpec &file) { return false; }
 
 #ifndef _WIN32
 
-#if defined(__AIX__)
+#if defined(_AIX)
 
 #include <stdio.h>
 extern char **p_xargv;
@@ -525,7 +525,7 @@ static int dladdr(const void *ptr, Dl_info *dl)
 FileSpec Host::GetModuleFileSpecForHostAddress(const void *host_addr) {
   FileSpec module_filespec;
 #if !defined(__ANDROID__)
-#ifdef __AIX__
+#ifdef _AIX
   if (host_addr == reinterpret_cast<void *>(HostInfoBase::ComputeSharedLibraryDirectory)) {
     // FIXME: AIX dladdr return "lldb" for this case
     if (p_xargv[0]) {

--- a/lldb/source/Host/common/XML.cpp
+++ b/lldb/source/Host/common/XML.cpp
@@ -10,7 +10,7 @@
 #include "lldb/Host/XML.h"
 
 #include "llvm/ADT/StringExtras.h"
-#if defined(__AIX__)
+#if defined(_AIX)
 #undef LLDB_ENABLE_LIBXML2
 #endif
 

--- a/lldb/source/Host/posix/ConnectionFileDescriptorPosix.cpp
+++ b/lldb/source/Host/posix/ConnectionFileDescriptorPosix.cpp
@@ -722,7 +722,7 @@ ConnectionFileDescriptor::ConnectFD(llvm::StringRef s,
 ConnectionStatus ConnectionFileDescriptor::ConnectFile(
     llvm::StringRef s, socket_id_callback_type socket_id_callback,
     Status *error_ptr) {
-#if !defined(__AIX__)
+#if !defined(_AIX)
 #if LLDB_ENABLE_POSIX
   std::string addr_str = s.str();
   // file:///PATH

--- a/lldb/source/Host/posix/FileSystemPosix.cpp
+++ b/lldb/source/Host/posix/FileSystemPosix.cpp
@@ -11,7 +11,7 @@
 // C includes
 #include <dirent.h>
 #include <fcntl.h>
-#if !defined(__AIX__)
+#if !defined(_AIX)
 #include <sys/mount.h>
 #endif
 #include <sys/param.h>

--- a/lldb/source/Host/posix/MainLoopPosix.cpp
+++ b/lldb/source/Host/posix/MainLoopPosix.cpp
@@ -179,7 +179,7 @@ Status MainLoopPosix::RunImpl::Poll() {
     read_fds.push_back(pfd);
   }
 
-#if defined(__AIX__)
+#if defined(_AIX)
   sigset_t origmask;
   int timeout;
 
@@ -325,7 +325,7 @@ MainLoopPosix::RegisterSignal(int signo, const Callback &callback,
   // If we're using kqueue, the signal needs to be unblocked in order to
   // receive it. If using pselect/ppoll, we need to block it, and later unblock
   // it as a part of the system call.
-#if defined(__AIX__)
+#if defined(_AIX)
   //FIXME: where is signal unblocked?
   ret = pthread_sigmask(SIG_UNBLOCK, &new_action.sa_mask, &old_set);
 #else

--- a/lldb/source/Host/posix/ProcessLauncherPosixFork.cpp
+++ b/lldb/source/Host/posix/ProcessLauncherPosixFork.cpp
@@ -193,7 +193,7 @@ struct ForkLaunchInfo {
     }
 
     // Start tracing this child that is about to exec.
-#if !defined(__AIX__)
+#if !defined(_AIX)
     if (ptrace(PT_TRACE_ME, 0, nullptr, 0) == -1)
       ExitWithError(error_fd, "ptrace");
 #else

--- a/lldb/source/Initialization/SystemInitializerCommon.cpp
+++ b/lldb/source/Initialization/SystemInitializerCommon.cpp
@@ -19,7 +19,7 @@
 #include "lldb/Version/Version.h"
 
 #if defined(__linux__) || defined(__FreeBSD__) || defined(__NetBSD__) ||       \
-    defined(__OpenBSD__) || defined(__AIX__)
+    defined(__OpenBSD__) || defined(_AIX)
 #include "Plugins/Process/POSIX/ProcessPOSIXLog.h"
 #endif
 
@@ -79,7 +79,7 @@ llvm::Error SystemInitializerCommon::Initialize() {
   process_gdb_remote::ProcessGDBRemoteLog::Initialize();
 
 #if defined(__linux__) || defined(__FreeBSD__) || defined(__NetBSD__) ||       \
-    defined(__OpenBSD__) || defined(__AIX__)
+    defined(__OpenBSD__) || defined(_AIX)
   ProcessPOSIXLog::Initialize();
 #endif
 #if defined(_WIN32)

--- a/lldb/source/Plugins/ABI/PowerPC/ABISysV_ppc64.cpp
+++ b/lldb/source/Plugins/ABI/PowerPC/ABISysV_ppc64.cpp
@@ -156,7 +156,7 @@ bool ABISysV_ppc64::PrepareTrivialCall(Thread &thread, addr_t sp,
   if (!reg_ctx->WriteRegisterFromUnsigned(r12_reg_info, func_addr))
     return false;
 
-#if defined(__AIX__)
+#if defined(_AIX)
   assert(0);
 #else
   // Read TOC pointer value.
@@ -279,7 +279,7 @@ bool ABISysV_ppc64::PrepareTrivialCall(Thread &thread, addr_t sp,
   if (!reg_ctx->WriteRegisterFromUnsigned(r12_reg_info, func_addr))
     return false;
 
-#if defined(__AIX__)
+#if defined(_AIX)
   LLDB_LOGF(log, "Writing R2: 0x%" PRIx64, (uint64_t)toc_addr);
   if (!reg_ctx->WriteRegisterFromUnsigned(r2_reg_info, toc_addr))
     return false;

--- a/lldb/source/Plugins/DynamicLoader/AIX-DYLD/DynamicLoaderAIXDYLD.cpp
+++ b/lldb/source/Plugins/DynamicLoader/AIX-DYLD/DynamicLoaderAIXDYLD.cpp
@@ -18,7 +18,7 @@
 #include "lldb/Target/ThreadPlanStepInstruction.h"
 #include "lldb/Utility/LLDBLog.h"
 #include "lldb/Utility/Log.h"
-#if defined(__AIX__)
+#if defined(_AIX)
 #include <sys/ldr.h>
 #endif
 
@@ -160,7 +160,7 @@ void DynamicLoaderAIXDYLD::DidAttach() {
   auto error = m_process->LoadModules();
   LLDB_LOG_ERROR(log, std::move(error), "failed to load modules: {0}");
 
-#if defined(__AIX__)
+#if defined(_AIX)
   // Get struct ld_xinfo (FIXME)
   struct ld_xinfo ldinfo[64];
   Status status = m_process->GetLDXINFO(&(ldinfo[0]));
@@ -221,7 +221,7 @@ void DynamicLoaderAIXDYLD::DidLaunch() {
     LLDB_LOG_ERROR(log, std::move(error), "failed to load modules: {0}");
   }
 
-#if defined(__AIX__)
+#if defined(_AIX)
   // Get struct ld_xinfo (FIXME)
   struct ld_xinfo ldinfo[64];
   Status status = m_process->GetLDXINFO(&(ldinfo[0]));

--- a/lldb/source/Plugins/Instruction/PPC64/EmulateInstructionPPC64.h
+++ b/lldb/source/Plugins/Instruction/PPC64/EmulateInstructionPPC64.h
@@ -39,7 +39,7 @@ public:
       return true;
 
     case eInstructionTypePCModifying:
-#if defined(__AIX__)
+#if defined(_AIX)
       return true;
 #else
       return false;

--- a/lldb/source/Plugins/JITLoader/GDB/JITLoaderGDB.cpp
+++ b/lldb/source/Plugins/JITLoader/GDB/JITLoaderGDB.cpp
@@ -194,7 +194,7 @@ void JITLoaderGDB::SetJITBreakpoint(lldb_private::ModuleList &module_list) {
   if (jit_addr == LLDB_INVALID_ADDRESS)
     return;
 
-#if defined(__AIX__)
+#if defined(_AIX)
   return;
 #endif
 

--- a/lldb/source/Plugins/Language/ObjC/Cocoa.cpp
+++ b/lldb/source/Plugins/Language/ObjC/Cocoa.cpp
@@ -1227,7 +1227,7 @@ bool lldb_private::formatters::ObjCSELSummaryProvider(
 time_t lldb_private::formatters::GetOSXEpoch() {
   static time_t epoch = 0;
   if (!epoch) {
-#if !defined(__AIX__)
+#if !defined(_AIX)
 #ifndef _WIN32
     tzset();
     tm tm_epoch;

--- a/lldb/source/Plugins/ObjectContainer/BSD-Archive/ObjectContainerBSDArchive.cpp
+++ b/lldb/source/Plugins/ObjectContainer/BSD-Archive/ObjectContainerBSDArchive.cpp
@@ -8,7 +8,7 @@
 
 #include "ObjectContainerBSDArchive.h"
 
-#if defined(_WIN32) || defined(__ANDROID__) || defined(__AIX__)
+#if defined(_WIN32) || defined(__ANDROID__) || defined(_AIX)
 // Defines from ar, missing on Windows
 #define SARMAG 8
 #define ARFMAG "`\n"

--- a/lldb/source/Plugins/ObjectContainer/Big-Archive/ObjectContainerBigArchive.cpp
+++ b/lldb/source/Plugins/ObjectContainer/Big-Archive/ObjectContainerBigArchive.cpp
@@ -8,7 +8,7 @@
 
 #include "ObjectContainerBigArchive.h"
 
-#if defined(_WIN32) || defined(__ANDROID__) || defined(__AIX__)
+#if defined(_WIN32) || defined(__ANDROID__) || defined(_AIX)
 // Defines from ar, missing on Windows
 #define ARMAG "!<arch>\n"
 #define SARMAG 8

--- a/lldb/source/Plugins/ObjectFile/Minidump/ObjectFileMinidump.cpp
+++ b/lldb/source/Plugins/ObjectFile/Minidump/ObjectFileMinidump.cpp
@@ -51,7 +51,7 @@ size_t ObjectFileMinidump::GetModuleSpecifications(
     const lldb_private::FileSpec &file, lldb::DataBufferSP &data_sp,
     lldb::offset_t data_offset, lldb::offset_t file_offset,
     lldb::offset_t length, lldb_private::ModuleSpecList &specs) {
-#if !defined(__AIX__)
+#if !defined(_AIX)
   specs.Clear();
 #endif
   return 0;

--- a/lldb/source/Plugins/ObjectFile/PDB/ObjectFilePDB.cpp
+++ b/lldb/source/Plugins/ObjectFile/PDB/ObjectFilePDB.cpp
@@ -117,7 +117,7 @@ size_t ObjectFilePDB::GetModuleSpecifications(
   llvm::BumpPtrAllocator allocator;
   std::unique_ptr<PDBFile> pdb_file = loadPDBFile(file.GetPath(), allocator);
   if (!pdb_file){
-#if !defined(__AIX__)
+#if !defined(_AIX)
     return initial_count;
 #else
     return specs.GetSize() - initial_count;
@@ -127,7 +127,7 @@ size_t ObjectFilePDB::GetModuleSpecifications(
   auto info_stream = pdb_file->getPDBInfoStream();
   if (!info_stream) {
     llvm::consumeError(info_stream.takeError());
-#if !defined(__AIX__)
+#if !defined(_AIX)
     return initial_count;
 #else
     return specs.GetSize() - initial_count;
@@ -136,7 +136,7 @@ size_t ObjectFilePDB::GetModuleSpecifications(
   auto dbi_stream = pdb_file->getPDBDbiStream();
   if (!dbi_stream) {
     llvm::consumeError(dbi_stream.takeError());
-#if !defined(__AIX__)
+#if !defined(_AIX)
     return initial_count;
 #else
     return specs.GetSize() - initial_count;

--- a/lldb/source/Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.cpp
+++ b/lldb/source/Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.cpp
@@ -254,7 +254,7 @@ size_t ObjectFilePECOFF::GetModuleSpecifications(
     lldb::offset_t length, lldb_private::ModuleSpecList &specs) {
   const size_t initial_count = specs.GetSize();
   if (!data_sp || !ObjectFilePECOFF::MagicBytesMatch(data_sp)){
-#if !defined(__AIX__)
+#if !defined(_AIX)
     return initial_count;
 #else
     return specs.GetSize() - initial_count;
@@ -272,7 +272,7 @@ size_t ObjectFilePECOFF::GetModuleSpecifications(
   if (!binary) {
     LLDB_LOG_ERROR(log, binary.takeError(),
                    "Failed to create binary for file ({1}): {0}", file);
-#if !defined(__AIX__)
+#if !defined(_AIX)
     return initial_count;
 #else
     return specs.GetSize() - initial_count;
@@ -281,7 +281,7 @@ size_t ObjectFilePECOFF::GetModuleSpecifications(
 
   auto *COFFObj = llvm::dyn_cast<llvm::object::COFFObjectFile>(binary->get());
   if (!COFFObj){
-#if !defined(__AIX__)
+#if !defined(_AIX)
     return initial_count;
 #else
     return specs.GetSize() - initial_count;

--- a/lldb/source/Plugins/Platform/AIX/PlatformAIX.cpp
+++ b/lldb/source/Plugins/Platform/AIX/PlatformAIX.cpp
@@ -31,7 +31,7 @@
 // Define these constants from AIX mman.h for use when targeting remote aix
 // systems even when host has different values.
 
-#if defined(__AIX__)
+#if defined(_AIX)
 #include <sys/mman.h>
 #endif
 
@@ -80,7 +80,7 @@ void PlatformAIX::Initialize() {
   PlatformPOSIX::Initialize();
 
   if (g_initialize_count++ == 0) {
-#if defined(__AIX__)
+#if defined(_AIX)
     PlatformSP default_platform_sp(new PlatformAIX(true));
     default_platform_sp->SetSystemArchitecture(HostInfo::GetArchitecture());
     Platform::SetHostPlatform(default_platform_sp);
@@ -294,7 +294,7 @@ MmapArgList PlatformAIX::GetMmapArgumentList(const ArchSpec &arch,
                                                addr_t addr, addr_t length,
                                                unsigned prot, unsigned flags,
                                                addr_t fd, addr_t offset) {
-#if defined(__AIX__)
+#if defined(_AIX)
   unsigned flags_platform = MAP_VARIABLE | MAP_PRIVATE | MAP_ANONYMOUS;
 #else
   unsigned flags_platform = 0;

--- a/lldb/source/Plugins/Process/Utility/InferiorCallPOSIX.cpp
+++ b/lldb/source/Plugins/Process/Utility/InferiorCallPOSIX.cpp
@@ -46,7 +46,7 @@ bool lldb_private::InferiorCallMmap(Process *process, addr_t &allocated_addr,
   function_options.include_inlines = false;
 
   SymbolContextList sc_list;
-#if !defined(__AIX__)
+#if !defined(_AIX)
   process->GetTarget().GetImages().FindFunctions(
       ConstString("mmap"), eFunctionNameTypeFull, function_options, sc_list);
 #else
@@ -122,7 +122,7 @@ bool lldb_private::InferiorCallMmap(Process *process, addr_t &allocated_addr,
         MmapArgList args =
             process->GetTarget().GetPlatform()->GetMmapArgumentList(
                 arch, addr, length, prot_arg, flags, fd, offset);
-#if defined(__AIX__)
+#if defined(_AIX)
         lldb::ThreadPlanSP call_plan_sp(
             new ThreadPlanCallFunction(*thread, mmap_range.GetBaseAddress(),
                                        toc_range.GetBaseAddress(),

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.cpp
@@ -41,7 +41,7 @@
 #include "llvm/Config/llvm-config.h" // for LLVM_ENABLE_ZLIB
 #include "llvm/Support/JSON.h"
 
-#if defined(__AIX__)
+#if defined(_AIX)
 #include <sys/ldr.h>
 #endif
 
@@ -1715,7 +1715,7 @@ Status GDBRemoteCommunicationClient::GetMemoryRegionInfo(
   return error;
 }
 
-#if defined(__AIX__)
+#if defined(_AIX)
 Status GDBRemoteCommunicationClient::GetLDXINFO(struct ld_xinfo *info_ptr)
 {
   Status error;

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.h
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.h
@@ -32,7 +32,7 @@
 
 #include "llvm/Support/VersionTuple.h"
 
-#if defined(__AIX__)
+#if defined(_AIX)
 struct ld_xinfo;
 #endif
 
@@ -200,7 +200,7 @@ public:
   Status GetMemoryRegionInfo(lldb::addr_t addr, MemoryRegionInfo &range_info);
 
   std::optional<uint32_t> GetWatchpointSlotCount();
-#if defined(__AIX__)
+#if defined(_AIX)
   Status GetLDXINFO(struct ld_xinfo *info_ptr);
 #endif
 

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.cpp
@@ -48,7 +48,7 @@
 #include "ProcessGDBRemote.h"
 #include "ProcessGDBRemoteLog.h"
 #include "lldb/Utility/StringExtractorGDBRemote.h"
-#if defined(__AIX__)
+#if defined(_AIX)
 #include <sys/ldr.h>
 #endif
 
@@ -3011,7 +3011,7 @@ GDBRemoteCommunicationServerLLGS::Handle_qLDXINFO(StringExtractorGDBRemote &pack
     return SendErrorResponse(0xff);
   }
 
-#if defined(__AIX__)
+#if defined(_AIX)
   // FIXME: buffer size
   struct ld_xinfo info[64];
   if (ptrace64(PT_LDXINFO, m_current_process->GetID(), (long long)&(info[0]), sizeof(info), nullptr) != 0) {

--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
@@ -92,7 +92,7 @@
 #include "llvm/Support/Threading.h"
 #include "llvm/Support/raw_ostream.h"
 
-#if defined(__AIX__)
+#if defined(_AIX)
 #include <sys/ldr.h>
 #endif
 
@@ -2963,7 +2963,7 @@ Status ProcessGDBRemote::DoGetMemoryRegionInfo(addr_t load_addr,
   return error;
 }
 
-#if defined(__AIX__)
+#if defined(_AIX)
 Status ProcessGDBRemote::DoGetLDXINFO(struct ld_xinfo *info_ptr) {
   Status error(m_gdb_comm.GetLDXINFO(info_ptr));
   return error;

--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.h
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.h
@@ -37,7 +37,7 @@
 #include "GDBRemoteCommunicationClient.h"
 #include "GDBRemoteRegisterContext.h"
 
-#if defined(__AIX__)
+#if defined(_AIX)
 struct ld_xinfo;
 #endif
 
@@ -427,7 +427,7 @@ protected:
   Status DoGetMemoryRegionInfo(lldb::addr_t load_addr,
                                MemoryRegionInfo &region_info) override;
 
-#if defined(__AIX__)
+#if defined(_AIX)
   Status DoGetLDXINFO(struct ld_xinfo *info_ptr) override;
 #endif
 

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -75,7 +75,7 @@
 #include "lldb/Utility/State.h"
 #include "lldb/Utility/Timer.h"
 
-#if defined(__AIX__)
+#if defined(_AIX)
 #include <sys/ldr.h>
 #endif
 
@@ -6188,7 +6188,7 @@ Status Process::GetMemoryRegionInfo(lldb::addr_t load_addr,
   return DoGetMemoryRegionInfo(load_addr, range_info);
 }
 
-#if defined(__AIX__)
+#if defined(_AIX)
 Status Process::GetLDXINFO(struct ld_xinfo *info_ptr) {
   return DoGetLDXINFO(info_ptr);
 }

--- a/lldb/source/Target/RegisterContextUnwind.cpp
+++ b/lldb/source/Target/RegisterContextUnwind.cpp
@@ -40,7 +40,7 @@
 
 #include <cassert>
 #include <memory>
-#ifdef __AIX__
+#ifdef _AIX
 #include "Plugins/Process/Utility/lldb-ppc64le-register-enums.h"
 #endif
 
@@ -1260,7 +1260,7 @@ bool RegisterContextUnwind::IsTrapHandlerSymbol(
 // Answer the question: Where did THIS frame save the CALLER frame ("previous"
 // frame)'s register value?
 
-#ifdef __AIX__
+#ifdef _AIX
 extern bool UGLY_HACK_NULL_TOPFRAME;
 #endif
 
@@ -1525,7 +1525,7 @@ RegisterContextUnwind::SavedLocationForRegister(
       new_regloc.type =
           UnwindLLDB::ConcreteRegisterLocation::eRegisterInLiveRegisterContext;
       new_regloc.location.register_number = regnum.GetAsKind(eRegisterKindLLDB);
-#ifdef __AIX__
+#ifdef _AIX
       if (UGLY_HACK_NULL_TOPFRAME && new_regloc.location.register_number == 0x20) {
         new_regloc.location.register_number = 0x24;
       }
@@ -2390,7 +2390,7 @@ bool RegisterContextUnwind::ReadPC(addr_t &pc) {
   }
 }
 
-#ifdef __AIX__
+#ifdef _AIX
 bool RegisterContextUnwind::ReadLR(addr_t &lr) {
   if (!IsValid())
     return false;

--- a/lldb/source/Target/UnwindLLDB.cpp
+++ b/lldb/source/Target/UnwindLLDB.cpp
@@ -68,7 +68,7 @@ uint32_t UnwindLLDB::DoGetFrameCount() {
   return m_frames.size();
 }
 
-#ifdef __AIX__
+#ifdef _AIX
 bool UGLY_HACK_NULL_TOPFRAME = false;
 #endif
 
@@ -95,7 +95,7 @@ bool UnwindLLDB::AddFirstFrame() {
   if (!reg_ctx_sp->ReadPC(first_cursor_sp->start_pc))
     goto unwind_done;
 
-#ifdef __AIX__
+#ifdef _AIX
   lldb::addr_t lr;
   if (!reg_ctx_sp->ReadLR(lr))
     goto unwind_done;

--- a/lldb/tools/driver/Driver.cpp
+++ b/lldb/tools/driver/Driver.cpp
@@ -640,7 +640,7 @@ void sigwinch_handler(int signo) {
 }
 
 void sigint_handler(int signo) {
-#if defined(_WIN32) || defined(__AIX__) // Restore handler as it is not persistent on Windows
+#if defined(_WIN32) || defined(_AIX) // Restore handler as it is not persistent on Windows
   signal(SIGINT, sigint_handler);
 #endif
   static std::atomic_flag g_interrupt_sent = ATOMIC_FLAG_INIT;
@@ -729,7 +729,7 @@ EXAMPLES:
 int main(int argc, char const *argv[]) {
   // Editline uses for example iswprint which is dependent on LC_CTYPE.
   // FIXME: this caused unexpected SIGTRAP on AIX
-#ifndef __AIX__
+#ifndef _AIX
   std::setlocale(LC_ALL, "");
   std::setlocale(LC_CTYPE, "");
 #endif

--- a/lldb/tools/lldb-server/SystemInitializerLLGS.cpp
+++ b/lldb/tools/lldb-server/SystemInitializerLLGS.cpp
@@ -14,7 +14,7 @@ using HostObjectFile = ObjectFileMachO;
 #elif defined(_WIN32)
 #include "Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.h"
 using HostObjectFile = ObjectFilePECOFF;
-#elif defined(__AIX__)
+#elif defined(_AIX)
 #include "Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.h"
 using HostObjectFile = ObjectFileXCOFF;
 #else
@@ -49,7 +49,7 @@ using HostObjectFile = ObjectFileELF;
 #include "Plugins/Instruction/MIPS/EmulateInstructionMIPS.h"
 #endif
 
-#if defined(__AIX__)
+#if defined(_AIX)
 #include "Plugins/Instruction/PPC64/EmulateInstructionPPC64.h"
 #endif
 
@@ -82,7 +82,7 @@ llvm::Error SystemInitializerLLGS::Initialize() {
   EmulateInstructionRISCV::Initialize();
 #endif
 
-#if defined(__AIX__)
+#if defined(_AIX)
   EmulateInstructionPPC64::Initialize();
 #endif
 
@@ -108,7 +108,7 @@ void SystemInitializerLLGS::Terminate() {
   EmulateInstructionRISCV::Terminate();
 #endif
 
-#if defined(__AIX__)
+#if defined(_AIX)
   EmulateInstructionPPC64::Terminate();
 #endif
 

--- a/lldb/tools/lldb-server/lldb-gdbserver.cpp
+++ b/lldb/tools/lldb-server/lldb-gdbserver.cpp
@@ -45,7 +45,7 @@
 #include "Plugins/Process/NetBSD/NativeProcessNetBSD.h"
 #elif defined(_WIN32)
 #include "Plugins/Process/Windows/Common/NativeProcessWindows.h"
-#elif defined(__AIX__)
+#elif defined(_AIX)
 #include "Plugins/Process/AIX/NativeProcessAIX.h"
 #endif
 
@@ -72,7 +72,7 @@ typedef process_freebsd::NativeProcessFreeBSD::Manager NativeProcessManager;
 typedef process_netbsd::NativeProcessNetBSD::Manager NativeProcessManager;
 #elif defined(_WIN32)
 typedef NativeProcessWindows::Manager NativeProcessManager;
-#elif defined(__AIX__)
+#elif defined(_AIX)
 typedef process_aix::NativeProcessAIX::Manager NativeProcessManager;
 #else
 // Dummy implementation to make sure the code compiles

--- a/lldb/unittests/Host/MainLoopTest.cpp
+++ b/lldb/unittests/Host/MainLoopTest.cpp
@@ -223,7 +223,7 @@ TEST_F(MainLoopTest, PendingCallbackAfterLoopExited) {
     loop.AddPendingCallback([&](MainLoopBase &loop) {});
 }
 
-#if defined(LLVM_ON_UNIX) && !defined(__AIX__)
+#if defined(LLVM_ON_UNIX) && !defined(_AIX)
 TEST_F(MainLoopTest, DetectsEOF) {
 
   PseudoTerminal term;

--- a/lldb/unittests/Host/PipeTest.cpp
+++ b/lldb/unittests/Host/PipeTest.cpp
@@ -55,7 +55,7 @@ TEST_F(PipeTest, OpenAsReader) {
 }
 #endif
 
-#if !defined(__AIX__)
+#if !defined(_AIX)
 TEST_F(PipeTest, WriteWithTimeout) {
   Pipe pipe;
   ASSERT_THAT_ERROR(pipe.CreateNew(false).ToError(), llvm::Succeeded());

--- a/lldb/unittests/Host/posix/TerminalTest.cpp
+++ b/lldb/unittests/Host/posix/TerminalTest.cpp
@@ -94,14 +94,14 @@ TEST_F(TerminalTest, SetRaw) {
 TEST_F(TerminalTest, SetBaudRate) {
   struct termios terminfo;
 
-#if (defined(__AIX__) && defined(B38400)) || !defined(__AIX__)
+#if (defined(_AIX) && defined(B38400)) || !defined(_AIX)
   ASSERT_THAT_ERROR(m_term.SetBaudRate(38400), llvm::Succeeded());
   ASSERT_EQ(tcgetattr(m_fd, &terminfo), 0);
   EXPECT_EQ(cfgetispeed(&terminfo), static_cast<speed_t>(B38400));
   EXPECT_EQ(cfgetospeed(&terminfo), static_cast<speed_t>(B38400));
 #endif
 
-#if (defined(__AIX__) && defined(B115200)) || !defined(__AIX__)
+#if (defined(_AIX) && defined(B115200)) || !defined(_AIX)
   ASSERT_THAT_ERROR(m_term.SetBaudRate(115200), llvm::Succeeded());
   ASSERT_EQ(tcgetattr(m_fd, &terminfo), 0);
   EXPECT_EQ(cfgetispeed(&terminfo), static_cast<speed_t>(B115200));


### PR DESCRIPTION
Removed the temporary External CMAKE flag for AIX (__AIX__). 
Replaced it with (_AIX) provided by the llvm environment.