### PR TITLE
Fix for Process attach 

### DIFF
--- a/lldb/source/Plugins/DynamicLoader/AIX-DYLD/DynamicLoaderAIXDYLD.h
+++ b/lldb/source/Plugins/DynamicLoader/AIX-DYLD/DynamicLoaderAIXDYLD.h
@@ -24,7 +24,7 @@ public:
 
   static void Initialize();
   static void Terminate();
-  static llvm::StringRef GetPluginNameStatic() { return "windows-dyld"; }
+  static llvm::StringRef GetPluginNameStatic() { return "aix-dyld"; }
   static llvm::StringRef GetPluginDescriptionStatic();
 
   static DynamicLoader *CreateInstance(Process *process, bool force);
@@ -45,6 +45,9 @@ public:
 
 protected:
   lldb::addr_t GetLoadAddress(lldb::ModuleSP executable);
+
+  /// Loads Module from inferior process.
+  void ResolveExecutableModule(lldb::ModuleSP &module_sp);
 
 private:
   std::map<lldb::ModuleSP, lldb::addr_t> m_loaded_modules;


### PR DESCRIPTION
Test output:
```
# bin/lldb -p 31654244
(lldb) process attach --pid 31654244
Process 31654244 stopped
* thread #1, stop reason = signal SIGSTOP
    frame #0: 0x00000001000008a0 while1`main at while1.c:5
   2     {
   3             while(1)
   4             {
-> 5             int a = 10;
   6             a++;
   7             }
   8     }
Executable binary set to "/home/dhruv/LLDB_test/while1".
Architecture set to: powerpc64-ibm-aix.
(lldb) n
Process 31654244 stopped
* thread #1, stop reason = step over
    frame #0: 0x00000001000008a8 while1`main at while1.c:6
   3             while(1)
   4             {
   5             int a = 10;
-> 6             a++;
   7             }
   8     }
(lldb) bt
* thread #1, stop reason = step over
  * frame #0: 0x00000001000008a8 while1`main at while1.c:6
    frame #1: 0x00000001000004ac while1`__start + 116
(lldb) a
Ambiguous command 'a'. Possible matches:
        apropos
        add-dsym
        attach
(lldb) image list
[  0]                                                         /home/dhruv/LLDB_test/while1 
[  1]                                                         /usr/ccs/bin/usla64 
[  2]                                                         /usr/lib/libcrypt.a (shr_64.o)
[  3]                                                         /usr/lib/libc.a (shr_64.o)
(lldb) q
```