### PR TITLE
Resolving coredump issue while attach with library calls

### DIFF
--- a/lldb/include/lldb/Core/ModuleSpec.h
+++ b/lldb/include/lldb/Core/ModuleSpec.h
@@ -122,6 +122,8 @@ public:
   ConstString &GetObjectName() { return m_object_name; }
 
   ConstString GetObjectName() const { return m_object_name; }
+  
+  void SetObjectName(ConstString objName) { m_object_name = objName; }
 
   uint64_t GetObjectOffset() const { return m_object_offset; }
 

--- a/lldb/source/Core/ModuleList.cpp
+++ b/lldb/source/Core/ModuleList.cpp
@@ -260,7 +260,17 @@ void ModuleList::ReplaceEquivalent(
                                       module_sp->GetArchitecture());
     equivalent_module_spec.GetPlatformFileSpec() =
         module_sp->GetPlatformFileSpec();
-
+#ifdef _AIX
+    // To remove the exact equivalent module, the object name must be 
+    // specified. When the equivalent_module_spec object is created, its 
+    // object name is initially set to NULL. This is because the module_sp's 
+    // GetPath() returns a path in the format (/usr/ccs/libc.a), which does 
+    // not include the object name. As a result, MatchesModuleSpec may return 
+    // true even though the object name is NULL and doesn't match any loaded 
+    // module. To fix this, set the object name of the equivalent_module_spec 
+    // to be the same as the object name of the module_sp. */
+    equivalent_module_spec.SetObjectName(module_sp->GetObjectName());
+#endif
     size_t idx = 0;
     while (idx < m_modules.size()) {
       ModuleSP test_module_sp(m_modules[idx]);


### PR DESCRIPTION
Resolving coredump issue while attach with library calls.

The issue is because of the split libc in to two modules (shr_64.o & _shr_64.o) in AIX.

The LLDB was only loading one module at a time without comparing object name. 
Added changes to compare and load both module. 

Before Fix:
-----------------
(lldb) image list
[  0]                                                         /LLDB/hemang/testcase/t2 
[  1]                                                         /usr/ccs/bin/usla64 
[  2]                                                         /usr/lib/libcrypt.a (shr_64.o)
[  3]                                                         /usr/lib/libpthreads.a (shr_xpg5_64.o)
[  4]                                                         /usr/lib/libc.a (shr_64.o)

After Fix:
---------
(lldb) image list
[  0]                                                         /LLDB/hemang/testcase/t2 
[  1]                                                         /usr/ccs/bin/usla64 
[  2]                                                         /usr/lib/libpthreads.a (_shr_xpg5_64.o)
[  3]                                                         /usr/lib/libcrypt.a (shr_64.o)
[  4]                                                         /usr/lib/libc.a (_shr_64.o)
[  5]                                                         /usr/lib/libpthreads.a (shr_xpg5_64.o)
[  6]                                                         /usr/lib/libc.a (shr_64.o)
