### PR TITLE
Invalid DWARF rangelist

### DIFF
--- a/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.cpp
+++ b/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.cpp
@@ -578,6 +578,7 @@ SectionType ObjectFileXCOFF::GetSectionType(llvm::StringRef sect_name,
       .Case(".dwinfo", eSectionTypeDWARFDebugInfo)
       .Case(".dwline", eSectionTypeDWARFDebugLine)
       .Case(".dwabrev", eSectionTypeDWARFDebugAbbrev)
+      .Case(".dwrnges", eSectionTypeDWARFDebugRanges)
       .Default(eSectionTypeInvalid);
 
     if (section_type != eSectionTypeInvalid)


### PR DESCRIPTION
Getting below errors when DW_AT_ranges dwarf attribute present in the application. 
Because .debug_ranges section are not loaded in the LLDB context,
Now loaded the  .debug_ranges also, so LLDB can resolve the DW_AT_ranges

Testcase:
-------------------
#include <iostream>
#include <vector>

int main() {
    std::vector<int> numbers = { 5, 2, 7, 1, 8 };
    for (const auto& num : numbers) {
        std::cout << num << " ";
    }
    return 0;
}


Before FIX:
------------------
(0) root @ unobosdev001: /LLDB/hemang/testcase
£ /LLDB/hemang/build_1/bin/lldb iss_18
(lldb) b main
error: iss_18 [0x0000000000011f5d]: DIE has DW_AT_ranges(DW_FORM_data8 0x0000000000000000) attribute, but range extraction failed (invalid range list offset 0x0), please file a bug and attach the file at the start of this error message
Breakpoint 2: where = iss_18`main + 28 at iss_18.cpp:5, address = 0x000000010000093c



After FIX:
----------------
(0) root @ unobosdev001: /LLDB/hemang/testcase
£ /LLDB/hemang/build_1/bin/lldb iss_18
(lldb) b main
Breakpoint 2: where = iss_18`main + 28 at iss_18.cpp:5, address = 0x000000010000093c


