### PR TITLE
Get base address for each module for image list command

### DIFF
--- a/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.cpp
+++ b/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.cpp
@@ -717,7 +717,8 @@ lldb_private::Address ObjectFileXCOFF::GetEntryPointAddress() {
 }
 
 lldb_private::Address ObjectFileXCOFF::GetBaseAddress() {
-  return lldb_private::Address();
+  // Get base address of the section
+  return Address(GetSectionList()->GetSectionAtIndex(0), 0);
 }
 
 ObjectFile::Type ObjectFileXCOFF::CalculateType() {


### PR DESCRIPTION
GetBaseAddress() was unimplemented for XCOFF. 
Added support to get the base addresses of each loaded module.

without fix : (addresses are not printing in image list)
------------------
(lldb) image list
[  0]                                                         /LLDB/hemang/testcase/iss_43 
[  1]                                                         /usr/ccs/bin/usla64 
[  2]                                                         /usr/lib/libpthreads.a (_shr_xpg5_64.o)
[  3]                                                         /usr/lib/libcrypt.a (shr_64.o)
[  4]                                                         /usr/lib/libc.a (_shr_64.o)
[  5]                                                         /usr/lib/libpthreads.a (shr_xpg5_64.o)
[  6]                                                         /usr/lib/libc.a (shr_64.o)


with fix : (addresses are printing)
----------------------
(lldb) image list
[  0]                                      0x0000000100000438 /LLDB/hemang/testcase/iss_43 
[  1]                                      0x09fffffff0001000 /usr/ccs/bin/usla64 
[  2]                                      0x09000000006b2200 /usr/lib/libpthreads.a (_shr_xpg5_64.o)
[  3]                                      0x09000000006b1420 /usr/lib/libcrypt.a (shr_64.o)
[  4]                                      0x090000000022c900 /usr/lib/libc.a (_shr_64.o)
[  5]                                      0x09000000000b71f8 /usr/lib/libpthreads.a (shr_xpg5_64.o)
[  6]                                      0x09000000000001f8 /usr/lib/libc.a (shr_64.o)