### PR TITLE
[XCOFF][Community] New Implementation for ObjectFileXCOFF - 64/32 Bit

### DIFF
--- a/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.h
+++ b/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.h
@@ -56,17 +56,8 @@ public:
   static bool MagicBytesMatch(lldb::DataBufferSP &data_sp, lldb::addr_t offset,
                               lldb::addr_t length);
 
-  static lldb::SymbolType MapSymbolType(llvm::object::SymbolRef::Type sym_type);
-
   // PluginInterface protocol
   llvm::StringRef GetPluginName() override { return GetPluginNameStatic(); }
-
-  // LLVM RTTI support
-  static char ID;
-  bool isA(const void *ClassID) const override {
-    return ClassID == &ID || ObjectFile::isA(ClassID);
-  }
-  static bool classof(const ObjectFile *obj) { return obj->isA(&ID); }
 
   // ObjectFile Protocol.
   bool ParseHeader() override;
@@ -113,126 +104,45 @@ public:
   ObjectFile::Type CalculateType() override;
 
   ObjectFile::Strata CalculateStrata() override;
-
+  
   llvm::StringRef
   StripLinkerSymbolAnnotations(llvm::StringRef symbol_name) const override;
 
   void RelocateSection(lldb_private::Section *section) override;
 
-  lldb_private::DataExtractor ReadImageData(uint32_t offset, size_t size);
-
   ObjectFileXCOFF(const lldb::ModuleSP &module_sp, lldb::DataBufferSP data_sp,
-                lldb::offset_t data_offset, const lldb_private::FileSpec *file,
-                lldb::offset_t offset, lldb::offset_t length);
+                  lldb::offset_t data_offset,
+                  const lldb_private::FileSpec *file, lldb::offset_t offset,
+                  lldb::offset_t length);
 
   ObjectFileXCOFF(const lldb::ModuleSP &module_sp,
-                lldb::DataBufferSP header_data_sp,
-                const lldb::ProcessSP &process_sp, lldb::addr_t header_addr);
+                  lldb::DataBufferSP header_data_sp,
+                  const lldb::ProcessSP &process_sp, lldb::addr_t header_addr);
 
 protected:
-
-  typedef struct xcoff_header {
-    uint16_t magic;
-    uint16_t nsects;
-    uint32_t modtime;
-    uint64_t symoff;
-    uint32_t nsyms;
-    uint16_t auxhdrsize;
-    uint16_t flags;
-  } xcoff_header_t;
-
-  typedef struct xcoff_aux_header {
-    uint16_t AuxMagic;
-    uint16_t Version;
-    uint32_t ReservedForDebugger;
-    uint64_t TextStartAddr;
-    uint64_t DataStartAddr;
-    uint64_t TOCAnchorAddr;
-    uint16_t SecNumOfEntryPoint;
-    uint16_t SecNumOfText;
-    uint16_t SecNumOfData;
-    uint16_t SecNumOfTOC;
-    uint16_t SecNumOfLoader;
-    uint16_t SecNumOfBSS;
-    uint16_t MaxAlignOfText;
-    uint16_t MaxAlignOfData;
-    uint16_t ModuleType;
-    uint8_t CpuFlag;
-    uint8_t CpuType;
-    uint8_t TextPageSize;
-    uint8_t DataPageSize;
-    uint8_t StackPageSize;
-    uint8_t FlagAndTDataAlignment;
-    uint64_t TextSize;
-    uint64_t InitDataSize;
-    uint64_t BssDataSize;
-    uint64_t EntryPointAddr;
-    uint64_t MaxStackSize;
-    uint64_t MaxDataSize;
-    uint16_t SecNumOfTData;
-    uint16_t SecNumOfTBSS;
-    uint16_t XCOFF64Flag;
-  } xcoff_aux_header_t;
-
-  typedef struct section_header {
-    char name[8];
-    uint64_t phyaddr; // Physical Addr
-    uint64_t vmaddr;  // Virtual Addr
-    uint64_t size;    // Section size
-    uint64_t offset;  // File offset to raw data
-    uint64_t reloff;  // Offset to relocations
-    uint64_t lineoff; // Offset to line table entries
-    uint32_t nreloc;  // Number of relocation entries
-    uint32_t nline;   // Number of line table entries
-    uint32_t flags;
-  } section_header_t;
-
-  typedef struct xcoff_symbol {
-    uint64_t value;
-    uint32_t offset;
-    uint16_t sect;
-    uint16_t type;
-    uint8_t storage;
-    uint8_t naux;
-  } xcoff_symbol_t;
-
-  typedef struct xcoff_sym_csect_aux_entry {
-    uint32_t section_or_len_low_byte;
-    uint32_t parameter_hash_index;
-    uint16_t type_check_sect_num;
-    uint8_t symbol_alignment_and_type;
-    uint8_t storage_mapping_class;
-    uint32_t section_or_len_high_byte;
-    uint8_t pad;
-    uint8_t aux_type;
-  } xcoff_sym_csect_aux_entry_t;
-
-  static bool ParseXCOFFHeader(lldb_private::DataExtractor &data,
-                              lldb::offset_t *offset_ptr,
-                              xcoff_header_t &xcoff_header);
-  bool ParseXCOFFOptionalHeader(lldb_private::DataExtractor &data,
-                                lldb::offset_t *offset_ptr);
-  bool ParseSectionHeaders(uint32_t offset);
-
-  std::vector<LoadableData>
-  GetLoadableData(lldb_private::Target &target) override;
-
   static lldb::WritableDataBufferSP
   MapFileDataWritable(const lldb_private::FileSpec &file, uint64_t Size,
                       uint64_t Offset);
-  llvm::StringRef GetSectionName(const section_header_t &sect);
-  static lldb::SectionType GetSectionType(llvm::StringRef sect_name,
-                                          const section_header_t &sect);
-
+  std::vector<LoadableData>
+  GetLoadableData(lldb_private::Target &target) override;
   uint32_t ParseDependentModules();
-  typedef std::vector<section_header_t> SectionHeaderColl;
+
 
 private:
   bool CreateBinary();
+  template <typename T>
+  void
+  CreateSectionsWithBitness(lldb_private::SectionList &unified_section_list);
 
-  xcoff_header_t m_xcoff_header;
-  xcoff_aux_header_t m_xcoff_aux_header;
-  SectionHeaderColl m_sect_headers;
+  struct XCOFF32 {
+    using SectionHeader = llvm::object::XCOFFSectionHeader32;
+    static constexpr bool Is64Bit = false;
+  };
+  struct XCOFF64 {
+    using SectionHeader = llvm::object::XCOFFSectionHeader64;
+    static constexpr bool Is64Bit = true;
+  };
+
   std::unique_ptr<llvm::object::XCOFFObjectFile> m_binary;
   lldb_private::Address m_entry_point_address;
   std::optional<lldb_private::FileSpecList> m_deps_filespec;


### PR DESCRIPTION
This is the **New design** for the **ObjectFileXCOFF** using **LLVM interfaces**.

The intent for which I had to implement this is that
we don't need to create new structures and can use LLVM interfaces instead, which makes the code cleaner,
safer and more structured.
And community was not accepting the older design.

As a plus, I have also made sure that it is **able to handle 32 bit binaries too along with 64 bit**

I have discarded the older design and only kept whats necessary, without changing any existing behaviour.

Most of this code has already been reviewed and merged in the community,
so I am pulling it together again here in our fork branch.