### PR TITLE
Fix: Corrected offset to retrieve process name and process ID

### DIFF
--- a/lldb/source/Plugins/Process/aix-core/AIXCore.cpp
+++ b/lldb/source/Plugins/Process/aix-core/AIXCore.cpp
@@ -106,6 +106,12 @@ bool AIXCore64Header::ParseCoreHeader(lldb_private::DataExtractor &data,
 
     *offset += 104;
     lldb::offset_t offset_to_user = (*offset + sizeof(ThreadContext64));
+    // This offset calculation is due to the difference between
+    // AIX register size and LLDB register variables order.
+    // __context64 does not match RegContext
+    // To be modified
+    lldb::offset_t offset_to_user = (*offset + sizeof(__context64) +
+            sizeof(thrdentry64));
     int ret = 0;
     ret = ParseThreadContext(data, offset);
     ret = ParseUserData(data, &offset_to_user);


### PR DESCRIPTION
Corrected the offset to parse the process info (PID, Process Name)

**# Without fix:**

# build/bin/lldb -c /home/ravi/lldb_tests/core 
(lldb) target create --core "/home/ravi/lldb_tests/core"
Core file '/home/ravi/lldb_tests/core' (powerpc64) was loaded.
(lldb) bt
* thread #1, stop reason = SIGSEGV
  * frame #0: 0x0000000100000980 2testingcore`main at 1190304_short_testcase.c:8
    frame #1: 0x00000001000004ac 2testingcore`__start + 116
(lldb) process status
Process 18446744071562067992 stopped
* thread #1, stop reason = SIGSEGV
    frame #0: 0x0000000100000980 2testingcore`main at 1190304_short_testcase.c:8
   5         int x = 42;
   6         int *p = NULL;
   7         printf("pid[0x%x] ppid[0x%x]\n", getpid(), getppid());
-> 8         *p = x;  // Intentional crash
   9         return 0;
   10    }
(lldb) 

**# With Fix:**

# build/bin/lldb -c /home/ravi/lldb_tests/core 
(lldb) target create --core "/home/ravi/lldb_tests/core"
Core file '/home/ravi/lldb_tests/core' (powerpc64) was loaded.
(lldb) bt
* thread #1, name = '2testingcore', stop reason = SIGSEGV
  * frame #0: 0x0000000100000980 2testingcore`main at 1190304_short_testcase.c:8
    frame #1: 0x00000001000004ac 2testingcore`__start + 116
(lldb) process status
Process 35848570 stopped
* thread #1, name = '2testingcore', stop reason = SIGSEGV
    frame #0: 0x0000000100000980 2testingcore`main at 1190304_short_testcase.c:8
   5         int x = 42;
   6         int *p = NULL;
   7         printf("pid[0x%x] ppid[0x%x]\n", getpid(), getppid());
-> 8         *p = x;  // Intentional crash
   9         return 0;
   10    }
(lldb) 
