### PR TITLE
Path fallback for lldb binary

### DIFF
--- a/lldb/source/Host/common/HostInfoBase.cpp
+++ b/lldb/source/Host/common/HostInfoBase.cpp
@@ -125,6 +125,11 @@ FileSpec HostInfoBase::GetShlibDir() {
       g_fields->m_lldb_so_dir = FileSpec();
     Log *log = GetLog(LLDBLog::Host);
     LLDB_LOG(log, "shlib dir -> `{0}`", g_fields->m_lldb_so_dir);
+#if (_AIX)
+    if (!g_fields->m_lldb_so_dir)
+        g_fields->m_lldb_so_dir = FileSpec("/usr/bin/");
+    LLDB_LOG(log, "shlib dir -> `{0}`", g_fields->m_lldb_so_dir);
+#endif
   });
   return g_fields->m_lldb_so_dir;
 }
@@ -135,6 +140,11 @@ FileSpec HostInfoBase::GetSupportExeDir() {
       g_fields->m_lldb_support_exe_dir = FileSpec();
     Log *log = GetLog(LLDBLog::Host);
     LLDB_LOG(log, "support exe dir -> `{0}`", g_fields->m_lldb_support_exe_dir);
+#if (_AIX)
+    if (!g_fields->m_lldb_support_exe_dir)
+        g_fields->m_lldb_support_exe_dir = FileSpec("/usr/bin/");
+    LLDB_LOG(log, "support exe dir -> `{0}`", g_fields->m_lldb_support_exe_dir);
+#endif
   });
   return g_fields->m_lldb_support_exe_dir;
 }


### PR DESCRIPTION
Path fallback for lldb binary for it to correctly locate lldb-server 