### PR TITLE
32bit support P1

### DIFF
--- a/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.cpp
+++ b/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.cpp
@@ -62,8 +62,6 @@ void ObjectFileXCOFF::Terminate() {
   PluginManager::UnregisterPlugin(CreateInstance);
 }
 
-bool UGLY_FLAG_FOR_AIX __attribute__((weak)) = false;
-
 ObjectFile *ObjectFileXCOFF::CreateInstance(const lldb::ModuleSP &module_sp,
                                             DataBufferSP data_sp,
                                             lldb::offset_t data_offset,
@@ -97,7 +95,6 @@ ObjectFile *ObjectFileXCOFF::CreateInstance(const lldb::ModuleSP &module_sp,
   if (!objfile_up->ParseHeader())
     return nullptr;
 
-  UGLY_FLAG_FOR_AIX = true;
   return objfile_up.release();
 }
 
@@ -517,7 +514,10 @@ lldb_private::Address ObjectFileXCOFF::GetEntryPointAddress() {
       section_list->FindSectionContainingFileAddress(vm_addr));
   if (section_sp) {
     lldb::offset_t offset_ptr = section_sp->GetFileOffset() + (vm_addr - section_sp->GetFileAddress());
-    vm_addr = m_data.GetU64(&offset_ptr);
+    if(m_binary->is64Bit())
+        vm_addr = m_data.GetU64(&offset_ptr);
+    else
+        vm_addr = m_data.GetU32(&offset_ptr);
   }
 
   if (!section_list)

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFUnit.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFUnit.cpp
@@ -1081,24 +1081,7 @@ const lldb_private::DWARFDataExtractor &DWARFUnit::GetData() const {
              : m_dwarf.GetDWARFContext().getOrLoadDebugInfoData();
 }
 
-uint32_t DWARFUnit::GetHeaderByteSize() const {
-  switch (m_header.getUnitType()) {
-  case llvm::dwarf::DW_UT_compile:
-    if (UGLY_FLAG_FOR_AIX)
-      return 11 + 4/*GetDWARFSizeOfOffset*/;
-    else
-      return GetVersion() < 5 ? 11 : 12;
-  case llvm::dwarf::DW_UT_partial:
-    return GetVersion() < 5 ? 11 : 12;
-  case llvm::dwarf::DW_UT_skeleton:
-  case llvm::dwarf::DW_UT_split_compile:
-    return 20;
-  case llvm::dwarf::DW_UT_type:
-  case llvm::dwarf::DW_UT_split_type:
-    return GetVersion() < 5 ? 23 : 24;
-  }
-  llvm_unreachable("invalid UnitType.");
-}
+uint32_t DWARFUnit::GetHeaderByteSize() const { return m_header.getSize(); }
 
 std::optional<uint64_t>
 DWARFUnit::GetStringOffsetSectionItem(uint32_t index) const {

--- a/llvm/lib/DebugInfo/DWARF/DWARFUnit.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFUnit.cpp
@@ -251,16 +251,10 @@ Expected<uint64_t> DWARFUnit::getStringOffsetSectionItem(uint32_t Index) const {
   return DA.getRelocatedValue(ItemSize, &Offset);
 }
 
-bool UGLY_FLAG_FOR_AIX __attribute__((weak)) = false;
-
 Error DWARFUnitHeader::extract(DWARFContext &Context,
                                const DWARFDataExtractor &debug_info,
                                uint64_t *offset_ptr,
                                DWARFSectionKind SectionKind) {
-  if (UGLY_FLAG_FOR_AIX) {
-    // FIXME: hack to get version
-    *offset_ptr += 8;
-  }
   Offset = *offset_ptr;
   Error Err = Error::success();
   IndexEntry = nullptr;
@@ -273,13 +267,8 @@ Error DWARFUnitHeader::extract(DWARFContext &Context,
     AbbrOffset = debug_info.getRelocatedValue(
         FormParams.getDwarfOffsetByteSize(), offset_ptr, nullptr, &Err);
   } else {
-    if (UGLY_FLAG_FOR_AIX) {
-        AbbrOffset = debug_info.getRelocatedValue(
-            8, offset_ptr, nullptr, &Err);
-    } else {
-        AbbrOffset = debug_info.getRelocatedValue(
-            FormParams.getDwarfOffsetByteSize(), offset_ptr, nullptr, &Err);
-    }
+    AbbrOffset = debug_info.getRelocatedValue(
+        FormParams.getDwarfOffsetByteSize(), offset_ptr, nullptr, &Err);
     FormParams.AddrSize = debug_info.getU8(offset_ptr, &Err);
     // Fake a unit type based on the section type.  This isn't perfect,
     // but distinguishing compile and type units is generally enough.


### PR DESCRIPTION
32 bit binary support:


#  bin/lldb  ../testcase/t_32
(lldb) target create "../testcase/t_32"
Current executable set to '/LLDB/hemang/testcase/t_32' (powerpc64).
(lldb) b main
Breakpoint 1: where = t_32`main + 32 at t.c:5, address = 0x00000000100006d8
(lldb) r
Process 46399990 launched: '/LLDB/hemang/testcase/t_32' (powerpc64)
Process 46399990 stopped
* thread #1, name = 't_32', stop reason = breakpoint 1.1
    frame #0: 0x00000000100006d8 t_32`main at t.c:5
   2     #include <stdio.h>
   3     int main()
   4     {
-> 5             int a = 10;
   6         printf("a = %d, &a = 0x%p\n",a,&a);
   7             while(1)
   8                     sleep(10);
(lldb) n
Process 46399990 stopped
* thread #1, name = 't_32', stop reason = step over
    frame #0: 0x00000000100006dc t_32`main at t.c:6
   3     int main()
   4     {
   5             int a = 10;
-> 6         printf("a = %d, &a = 0x%p\n",a,&a);
   7             while(1)
   8                     sleep(10);
   9             return a;
(lldb) p a
(int) 10
(lldb) image list
[  0]                                      0x0000000010000268 /LLDB/hemang/testcase/t_32 
[  1]                                      0x00000000d0615240 /usr/lib/libcrypt.a (shr.o)
[  2]                                      0x00000000d019c300 /usr/lib/libc.a (_shr.o)
[  3]                                      0x00000000d0100124 /usr/lib/libc.a (shr.o)
(lldb) 