### PR TITLE
std:__1:string fix for AIX

### DIFF
--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxx.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxx.cpp
@@ -474,21 +474,22 @@ static ValueObjectSP ExtractLibCxxStringData(ValueObject &valobj) {
   return valobj_r_sp;
 }
 
-int parseChar(const std::string& input) {
-    // Check if input starts and ends with single quotes
-    if (input.size() >= 3 && input.front() == '\'' && input.back() == '\'') {
-        std::string inner = input.substr(1, input.size() - 2); // e.g., "\0" or "\x01"
+int parseChar(const std::string &input) {
+  // Check if input starts and ends with single quotes
+  if (input.size() >= 3 && input.front() == '\'' && input.back() == '\'') {
+    std::string inner =
+        input.substr(1, input.size() - 2); // e.g., "\0" or "\x01"
 
-        if (inner == "\\0" ) {
-            return 0;
-        }
-        if (inner.rfind("\\x", 0) == 0 && inner.size() == 4) {
-            std::string hexPart = inner.substr(2);
-            int value = std::stoi(hexPart, nullptr, 16);
-            return value;
-        }
+    if (inner == "\\0") {
+      return 0;
     }
-    return -1; // Invalid format
+    if (inner.rfind("\\x", 0) == 0 && inner.size() == 4) {
+      std::string hexPart = inner.substr(2);
+      int value = std::stoi(hexPart, nullptr, 16);
+      return value;
+    }
+  }
+  return -1; // Invalid format
 }
 
 /// Determine the size in bytes of \p valobj (a libc++ std::string object) and
@@ -514,8 +515,8 @@ ExtractLibcxxStringInfo(ValueObject &valobj) {
   StringLayout layout =
       *index_or_err == 0 ? StringLayout::DSC : StringLayout::CSD;
 
-  bool short_mode = false; // this means the string is in short-mode and the
-                           // data is stored inline
+  bool short_mode = false;    // this means the string is in short-mode and the
+                              // data is stored inline
   bool using_bitmasks = true; // Whether the class uses bitmasks for the mode
                               // flag (pre-D123580).
   uint64_t size;
@@ -537,7 +538,8 @@ ExtractLibcxxStringInfo(ValueObject &valobj) {
 #if _AIX
     short_mode = !parseChar(is_long->GetValueAsCString());
     size = parseChar(size_sp->GetValueAsCString());
-    if (size > 23) size = 0; // as it is garbage if not valid
+    if (size > 23)
+      size = 0; // as it is garbage if not valid
 #endif
 
   } else {
@@ -664,23 +666,23 @@ bool lldb_private::formatters::LibcxxStringSummaryProviderUTF32(
 }
 
 static std::tuple<bool, ValueObjectSP, size_t>
-LibcxxExtractStringViewData(ValueObject& valobj) {
+LibcxxExtractStringViewData(ValueObject &valobj) {
   auto dataobj = GetChildMemberWithName(
       valobj, {ConstString("__data_"), ConstString("__data")});
   auto sizeobj = GetChildMemberWithName(
       valobj, {ConstString("__size_"), ConstString("__size")});
   if (!dataobj || !sizeobj)
-    return std::make_tuple<bool,ValueObjectSP,size_t>(false, {}, {});
+    return std::make_tuple<bool, ValueObjectSP, size_t>(false, {}, {});
 
   if (!dataobj->GetError().Success() || !sizeobj->GetError().Success())
-    return std::make_tuple<bool,ValueObjectSP,size_t>(false, {}, {});
+    return std::make_tuple<bool, ValueObjectSP, size_t>(false, {}, {});
 
   bool success{false};
   uint64_t size = sizeobj->GetValueAsUnsigned(0, &success);
   if (!success)
-    return std::make_tuple<bool,ValueObjectSP,size_t>(false, {}, {});
+    return std::make_tuple<bool, ValueObjectSP, size_t>(false, {}, {});
 
-  return std::make_tuple(true,dataobj,size);
+  return std::make_tuple(true, dataobj, size);
 }
 
 template <StringPrinter::StringElementType element_type>

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxx.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxx.cpp
@@ -31,6 +31,7 @@
 #include "lldb/lldb-enumerations.h"
 #include "lldb/lldb-forward.h"
 #include <optional>
+#include <string>
 #include <tuple>
 
 using namespace lldb;
@@ -82,6 +83,7 @@ lldb_private::formatters::GetFirstValueOfLibCXXCompressedPair(
     // pre-c88580c member name
     value = pair.GetChildMemberWithName("__first_");
   }
+
   return value;
 }
 
@@ -472,6 +474,23 @@ static ValueObjectSP ExtractLibCxxStringData(ValueObject &valobj) {
   return valobj_r_sp;
 }
 
+int parseChar(const std::string& input) {
+    // Check if input starts and ends with single quotes
+    if (input.size() >= 3 && input.front() == '\'' && input.back() == '\'') {
+        std::string inner = input.substr(1, input.size() - 2); // e.g., "\0" or "\x01"
+
+        if (inner == "\\0" ) {
+            return 0;
+        }
+        if (inner.rfind("\\x", 0) == 0 && inner.size() == 4) {
+            std::string hexPart = inner.substr(2);
+            int value = std::stoi(hexPart, nullptr, 16);
+            return value;
+        }
+    }
+    return -1; // Invalid format
+}
+
 /// Determine the size in bytes of \p valobj (a libc++ std::string object) and
 /// extract its data payload. Return the size + payload pair.
 // TODO: Support big-endian architectures.
@@ -515,6 +534,12 @@ ExtractLibcxxStringInfo(ValueObject &valobj) {
     using_bitmasks = false;
     short_mode = !is_long->GetValueAsUnsigned(/*fail_value=*/0);
     size = size_sp->GetValueAsUnsigned(/*fail_value=*/0);
+#if _AIX
+    short_mode = !parseChar(is_long->GetValueAsCString());
+    size = parseChar(size_sp->GetValueAsCString());
+    if (size > 23) size = 0; // as it is garbage if not valid
+#endif
+
   } else {
     // The string mode is encoded in the size field.
     size_mode_value = size_sp->GetValueAsUnsigned(0);


### PR DESCRIPTION
Fixes issue

-  #76 

Without fix:
```
Process 15204610 stopped
thread https://github.com/DhruvSrivastavaX/lldb-for-aix/pull/1, stop reason = step over
frame #0: 0x000000010000097c fresh`main at fresh.cpp:14
11
12 // ...
13
-> 14 return 0;
15
16 }
(lldb) print p
(Person) (name = Summary Unavailable, age = 30, height = 1.6499999999999999) ======>>>> name is not printed here
(lldb) q
Quitting LLDB will kill one or more processes. Do you really want to proceed: [Y/n] y
```

With fix:
```
(lldb) n
Process 27197796 stopped
* thread #1, name = '1191468', stop reason = step over
    frame #0: 0x000000010000097c 1191468`main at 1191468.C:14
   11    
   12        // ...
   13    
-> 14        return 0;
   15    
   16    }
(lldb) p p
(Person)  (name = "Alice", age = 30, height = 1.6499999999999999)
```

Fixes both short string and long string:
```
(lldb) n
Process 26214908 stopped
* thread #1, name = '1191468_l', stop reason = step over
    frame #0: 0x00000001000009a4 1191468_l`main at 1191468_l.C:14
   11        std::string str = "Hello";
   12        std::string str_l = "Hello! This is a very very long string that goes beyond the short string limit";
   13        // ...
-> 14        std::cout << "string " << str << std::endl;
   15        std::cout << "string " << str_l << std::endl;
   16    
   17        return 0;
(lldb) p str
(std::__1::string) "Hello"
(lldb) p str_l
(std::__1::string) "Hello! This is a very very long string that goes beyond the short string limit"
```