### PR TITLE
[Cmake] Avoid build failures

### DIFF
--- a/lldb/source/Plugins/Process/gdb-remote/CMakeLists.txt
+++ b/lldb/source/Plugins/Process/gdb-remote/CMakeLists.txt
@@ -55,6 +55,8 @@ add_lldb_library(lldbPluginProcessGDBRemote PLUGIN
     ${LIBCOMPRESSION}
   )
 
+target_compile_definitions(lldbPluginProcessGDBRemote PRIVATE "-D_ALL_SOURCE") 
+
 add_dependencies(lldbPluginProcessGDBRemote
   LLDBPluginProcessGDBRemotePropertiesGen
   LLDBPluginProcessGDBRemotePropertiesEnumGen)

--- a/lldb/source/Target/CMakeLists.txt
+++ b/lldb/source/Target/CMakeLists.txt
@@ -107,3 +107,5 @@ add_lldb_library(lldbTarget
 add_dependencies(lldbTarget
   LLDBTargetPropertiesGen
   LLDBTargetPropertiesEnumGen)
+
+target_compile_definitions(lldbTarget PRIVATE "-D_ALL_SOURCE")


### PR DESCRIPTION
For AIX7.2 and 
sometimes for AIX7.3 as well (not always)
Build would fail due to unidentified macros in AIX.
Need to link the definitions correctly.

Errors such as these:
```
In file included from /home/dhruv/LLDB/lldb-for-aix/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp:26:
In file included from /home/dhruv/LLDB/lldb-for-aix/lldb/include/lldb/Breakpoint/Watchpoint.h:18:
In file included from /home/dhruv/LLDB/lldb-for-aix/lldb/include/lldb/Target/Target.h:24:
In file included from /home/dhruv/LLDB/lldb-for-aix/lldb/include/lldb/Core/ModuleList.h:13:
/home/dhruv/LLDB/lldb-for-aix/lldb/include/lldb/Core/ModuleSpec.h:51:27: warning: cast from 'const char *' to 'char *' drops const qualifier [-Wcast-qual]
      char *str = (char *)path_with_object.c_str();
                          ^
In file included from /home/dhruv/LLDB/lldb-for-aix/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp:98:
/usr/include/sys/ldr.h:168:2: error: unknown type name 'uint'; did you mean 'int'?
        __I_FIELDS(__I_INT64, __I_PTR64, __I_FP64, uint ldinfo_flags;)
        ^
/usr/include/sys/ldr.h:137:2: note: expanded from macro '__I_FIELDS'
        uint                    ldinfo_next;        /* offset from current     \
        ^
/usr/include/sys/ldr.h:168:45: error: unknown type name 'uint'; did you mean 'int'?
        __I_FIELDS(__I_INT64, __I_PTR64, __I_FP64, uint ldinfo_flags;)
...
...
...
```