### PR TITLE
Fix for executable error for relative path lldb

### DIFF
--- a/lldb/source/Host/common/HostInfoBase.cpp
+++ b/lldb/source/Host/common/HostInfoBase.cpp
@@ -129,7 +129,12 @@ FileSpec HostInfoBase::GetShlibDir() {
       g_fields->m_lldb_so_dir = FileSpec();
     Log *log = GetLog(LLDBLog::Host);
     LLDB_LOG(log, "shlib dir -> `{0}`", g_fields->m_lldb_so_dir);
-  });
+#if (_AIX)
+    if (!g_fields->m_lldb_so_dir)
+    g_fields->m_lldb_so_dir = FileSpec("/usr/bin/");
+    LLDB_LOG(log, "shlib dir -> `{0}`", g_fields->m_lldb_so_dir);
+#endif
+    });
   return g_fields->m_lldb_so_dir;
 }
 


### PR DESCRIPTION
Unable to locate executable or lldb-server in some cases
when relative path is different.
```
lldb test
(lldb) target create "test"
Current executable set to '/tests/lldb/test' (powerpc64).
(lldb) b main
Breakpoint 1: where = test`main + 44 at test.C:9, address = 0x000000001000074c
(lldb) r
error: executable doesn't exist: '(empty)'
(lldb) q
```