### PR TITLE
Fix for delay while quitting debugging session

### DIFF
--- a/lldb/source/Plugins/Process/AIX/NativeProcessAIX.cpp
+++ b/lldb/source/Plugins/Process/AIX/NativeProcessAIX.cpp
@@ -952,7 +952,7 @@ Status NativeProcessAIX::Kill() {
     // We can try to kill a process in these states.
     break;
   }
-
+  // PT_KILL will cause SIGCHLD to be triggered to server and cause a graceful exit.
   error = PtraceWrapper(PT_KILL, GetID(), nullptr, nullptr,  0, nullptr);
 
   return error;

--- a/lldb/source/Plugins/Process/AIX/NativeProcessAIX.cpp
+++ b/lldb/source/Plugins/Process/AIX/NativeProcessAIX.cpp
@@ -953,10 +953,7 @@ Status NativeProcessAIX::Kill() {
     break;
   }
 
-  if (kill(GetID(), SIGKILL) != 0) {
-    error = Status::FromErrno();
-    return error;
-  }
+  error = PtraceWrapper(PT_KILL, GetID(), nullptr, nullptr,  0, nullptr);
 
   return error;
 }
@@ -2061,7 +2058,7 @@ Status NativeProcessAIX::PtraceWrapper(int req, lldb::pid_t pid, void *addr,
         LLDB_LOG(log,"NativeProcessAIX::pthread_sigmask(SIG_UNBLOCK) Failed");
     } else if (req == PT_WATCH) {
       ptrace64(req, pid, (long long)addr, (int)data_size, nullptr);
-    } else if (req == PT_DETACH) {
+    } else if (req == PT_DETACH || req == PT_KILL) {
       ptrace64(req, pid, 0, 0, nullptr);
     } else {
       assert(0 && "Not supported yet.");


### PR DESCRIPTION
Once we have a running debuggee, LLDB takes a couple of seconds to quit.
This fix makes the quit, immediate.

```
(0) root @ unobosdev002: /home/dhruv/dio_fs/LLDB/build-lldb
# bin/lldb ../tests/1
(lldb) target create "../tests/1"
Current executable set to '/home/dhruv/dio_fs/LLDB/tests/1' (powerpc64).
(lldb) b main
Breakpoint 1: where = 1`main + 8 at 1.c:3, address = 0x00000001000008a0
(lldb) r
Process 30409082 launched: '/home/dhruv/dio_fs/LLDB/tests/1' (powerpc64)
Process 30409082 stopped
* thread #1, stop reason = breakpoint 1.1
    frame #0: 0x00000001000008a0 1`main at 1.c:3
   1     int main()
   2     {
-> 3         int x = 10;
   4         x++;
   5         return x;
   6     }
(lldb) q
Quitting LLDB will kill one or more processes. Do you really want to proceed: [Y/n] y
```