### PR TITLE
rerun coredump

### DIFF
--- a/lldb/source/Core/ModuleList.cpp
+++ b/lldb/source/Core/ModuleList.cpp
@@ -791,6 +791,7 @@ public:
     // because the module_spec has no filename or the found module has a
     // different filename. For example, when searching by UUID and finding a
     // module with an alias.
+#if !(_AIX)  
     assert((matching_module_list.IsEmpty() ||
             module_spec.GetFileSpec().GetFilename().IsEmpty() ||
             module_spec.GetFileSpec().GetFilename() !=
@@ -798,6 +799,7 @@ public:
                     ->GetFileSpec()
                     .GetFilename()) &&
            "Search by name not found in SharedModuleList's map");
+#endif
   }
 
   ModuleSP FindModule(const Module &module) {


### PR DESCRIPTION
Coredump fix patch for handling new code changes from community on rerun of binary.

```
(lldb) r
Process 26739144 launched: '/home/LLDB/tests/2' (powerpc64)
Process 26739144 stopped
* thread #1, name = '2', stop reason = breakpoint 1.1
    frame #0: 0x000000010000097c 2`main at 2.c:8
   5     }
   6     int main()
   7     {
-> 8         int a = 10;
   9             return a + func(a);
   10    }
(lldb) r
There is a running process, kill it and restart?: [Y/n] y
Process 26739144 exited with status = 9 (0x00000009) 
Assertion failed: (matching_module_list.IsEmpty() || module_spec.GetFileSpec().GetFilename().IsEmpty() || module_spec.GetFileSpec().GetFilename() != matching_module_list.GetModuleAtIndex(0) ->GetFileSpec() .GetFilename()) && "Search by name not found in SharedModuleList's map", file  /home/LLDB/lldb-for-aix/lldb/source/Core/ModuleList.cpp, line 800, void (anonymous namespace)::SharedModuleList::FindModules(const lldb_private::ModuleSpec &, lldb_private::ModuleList &) const()
PLEASE submit a bug report to https://github.com/llvm/llvm-project/issues/ and include the crash backtrace.
Stack dump:
0.      Program arguments: lldb /home/LLDB/tests/2
LLDB diagnostics will be written to /tmp/diagnostics-9f6eac
Please include the directory content when filing a bug report
IOT/Abort trap (core dumped)
```