### PR TITLE
disassembly fix for symbol resolution with branch statements.

### DIFF
--- a/lldb/source/Plugins/Disassembler/LLVMC/DisassemblerLLVMC.cpp
+++ b/lldb/source/Plugins/Disassembler/LLVMC/DisassemblerLLVMC.cpp
@@ -1398,7 +1398,7 @@ void DisassemblerLLVMC::MCDisasmInstance::PrintMCInst(
         lldb::addr_t target_addr = (lldb::addr_t)(pc + (op.getImm() << 2));
         target_address.SetLoadAddress(target_addr, target);
         target_address.CalculateSymbolContext(&sym_ctx);
-        if (sym_ctx.function || sym_ctx.symbol) {
+        if (sym_ctx.function && comments_string.empty()) {
           const char *func_name = sym_ctx.function->GetName().AsCString();
           if (sym_ctx.line_entry.IsValid()) {
             const char *file =
@@ -1407,6 +1407,9 @@ void DisassemblerLLVMC::MCDisasmInstance::PrintMCInst(
             comments_stream << func_name << " at " << file << ":" << line;
           } else
             comments_stream << func_name;
+        } else if (sym_ctx.symbol && comments_string.empty()) {
+          comments_stream << "symbol stub for: "
+                          << sym_ctx.symbol->GetName().AsCString();
         }
       }
     }

--- a/lldb/source/Plugins/Disassembler/LLVMC/DisassemblerLLVMC.cpp
+++ b/lldb/source/Plugins/Disassembler/LLVMC/DisassemblerLLVMC.cpp
@@ -1389,15 +1389,22 @@ void DisassemblerLLVMC::MCDisasmInstance::PrintMCInst(
   SymbolContext sym_ctx;
   Address target_address;
   for (unsigned i = 0; i < mc_inst.getNumOperands(); ++i) {
+
     const auto &op = mc_inst.getOperand(i);
     const llvm::MCInstrDesc &desc = m_instr_info_up->get(mc_inst.getOpcode());
+
     if (desc.isBranch() || desc.isCall()) {
       Target *target =
           m_owner.m_exe_ctx ? m_owner.m_exe_ctx->GetTargetPtr() : nullptr;
-      if (op.isImm()) {
+
+      if (op.isImm() && target) {
+        // The branch immediate omits the lowest two bits (zeros) to make
+        // it word aligned. So we require left shift of 2 bytes to calculate
+        // the actual branch target.
         lldb::addr_t target_addr = (lldb::addr_t)(pc + (op.getImm() << 2));
         target_address.SetLoadAddress(target_addr, target);
         target_address.CalculateSymbolContext(&sym_ctx);
+
         if (sym_ctx.function && comments_string.empty()) {
           const char *func_name = sym_ctx.function->GetName().AsCString();
           if (sym_ctx.line_entry.IsValid()) {
@@ -1407,13 +1414,14 @@ void DisassemblerLLVMC::MCDisasmInstance::PrintMCInst(
             comments_stream << func_name << " at " << file << ":" << line;
           } else
             comments_stream << func_name;
+
         } else if (sym_ctx.symbol && comments_string.empty()) {
           comments_stream << "symbol stub for: "
                           << sym_ctx.symbol->GetName().AsCString();
         }
-      }
-    }
-  }
+      } // if(op.isImm() && target)
+    } // if (desc.isBranch() || desc.isCall())
+  } // loop ends
 #endif
   m_instr_printer_up->printInst(&mc_inst, pc, llvm::StringRef(),
                                 *m_subtarget_info_up, inst_stream);

--- a/lldb/source/Plugins/Disassembler/LLVMC/DisassemblerLLVMC.cpp
+++ b/lldb/source/Plugins/Disassembler/LLVMC/DisassemblerLLVMC.cpp
@@ -81,7 +81,8 @@ private:
                    std::unique_ptr<llvm::MCContext> &&context_up,
                    std::unique_ptr<llvm::MCDisassembler> &&disasm_up,
                    std::unique_ptr<llvm::MCInstPrinter> &&instr_printer_up,
-                   std::unique_ptr<llvm::MCInstrAnalysis> &&instr_analysis_up);
+                   std::unique_ptr<llvm::MCInstrAnalysis> &&instr_analysis_up,
+                   DisassemblerLLVMC &owner);
 
   std::unique_ptr<llvm::MCInstrInfo> m_instr_info_up;
   std::unique_ptr<llvm::MCRegisterInfo> m_reg_info_up;
@@ -91,6 +92,7 @@ private:
   std::unique_ptr<llvm::MCDisassembler> m_disasm_up;
   std::unique_ptr<llvm::MCInstPrinter> m_instr_printer_up;
   std::unique_ptr<llvm::MCInstrAnalysis> m_instr_analysis_up;
+  DisassemblerLLVMC &m_owner;
 };
 
 namespace x86 {
@@ -1335,7 +1337,7 @@ DisassemblerLLVMC::MCDisasmInstance::Create(const char *triple_name,
       std::move(instr_info_up), std::move(reg_info_up),
       std::move(subtarget_info_up), std::move(asm_info_up),
       std::move(context_up), std::move(disasm_up), std::move(instr_printer_up),
-      std::move(instr_analysis_up)));
+      std::move(instr_analysis_up), owner));
 }
 
 DisassemblerLLVMC::MCDisasmInstance::MCDisasmInstance(
@@ -1346,14 +1348,15 @@ DisassemblerLLVMC::MCDisasmInstance::MCDisasmInstance(
     std::unique_ptr<llvm::MCContext> &&context_up,
     std::unique_ptr<llvm::MCDisassembler> &&disasm_up,
     std::unique_ptr<llvm::MCInstPrinter> &&instr_printer_up,
-    std::unique_ptr<llvm::MCInstrAnalysis> &&instr_analysis_up)
+    std::unique_ptr<llvm::MCInstrAnalysis> &&instr_analysis_up,
+    DisassemblerLLVMC &owner)
     : m_instr_info_up(std::move(instr_info_up)),
       m_reg_info_up(std::move(reg_info_up)),
       m_subtarget_info_up(std::move(subtarget_info_up)),
       m_asm_info_up(std::move(asm_info_up)),
       m_context_up(std::move(context_up)), m_disasm_up(std::move(disasm_up)),
       m_instr_printer_up(std::move(instr_printer_up)),
-      m_instr_analysis_up(std::move(instr_analysis_up)) {
+      m_instr_analysis_up(std::move(instr_analysis_up)), m_owner(owner) {
   assert(m_instr_info_up && m_reg_info_up && m_subtarget_info_up &&
          m_asm_info_up && m_context_up && m_disasm_up && m_instr_printer_up);
 }
@@ -1381,6 +1384,34 @@ void DisassemblerLLVMC::MCDisasmInstance::PrintMCInst(
 
   inst_stream.enable_colors(m_instr_printer_up->getUseColor());
   m_instr_printer_up->setCommentStream(comments_stream);
+
+#ifdef _AIX
+  SymbolContext sym_ctx;
+  Address target_address;
+  for (unsigned i = 0; i < mc_inst.getNumOperands(); ++i) {
+    const auto &op = mc_inst.getOperand(i);
+    const llvm::MCInstrDesc &desc = m_instr_info_up->get(mc_inst.getOpcode());
+    if (desc.isBranch() || desc.isCall()) {
+      Target *target =
+          m_owner.m_exe_ctx ? m_owner.m_exe_ctx->GetTargetPtr() : nullptr;
+      if (op.isImm()) {
+        lldb::addr_t target_addr = (lldb::addr_t)(pc + (op.getImm() << 2));
+        target_address.SetLoadAddress(target_addr, target);
+        target_address.CalculateSymbolContext(&sym_ctx);
+        if (sym_ctx.function || sym_ctx.symbol) {
+          const char *func_name = sym_ctx.function->GetName().AsCString();
+          if (sym_ctx.line_entry.IsValid()) {
+            const char *file =
+                sym_ctx.line_entry.GetFile().GetFilename().AsCString();
+            std::string line = std::to_string(sym_ctx.line_entry.line);
+            comments_stream << func_name << " at " << file << ":" << line;
+          } else
+            comments_stream << func_name;
+        }
+      }
+    }
+  }
+#endif
   m_instr_printer_up->printInst(&mc_inst, pc, llvm::StringRef(),
                                 *m_subtarget_info_up, inst_stream);
   m_instr_printer_up->setCommentStream(llvm::nulls());


### PR DESCRIPTION
Without fix:
```
# bin/lldb ../tests/1189804   
(lldb) target create "../tests/1189804"
Current executable set to '/home/dhruv/LLDB/tests/1189804' (powerpc64).
(lldb) b main
Breakpoint 1: where = 1189804`main + 28 at 1189804.c:24, address = 0x00000001000008b4
(lldb) r
Process 27591116 launched: '/home/dhruv/LLDB/tests/1189804' (powerpc64)
Process 27591116 stopped
* thread #1, name = '1189804', stop reason = breakpoint 1.1
    frame #0: 0x00000001000008b4 1189804`main at 1189804.c:24
   21       int choice;
   22  
   23       // Modify and print union data
-> 24       printf("Enter 1 for int, 2 for float, 3 for string: ");
   25       scanf("%d", &choice);
   26       modifyUnion(&data, choice);
   27       printUnion(&data);
(lldb) di
1189804`main:
    0x100000898 <+0>:   mflr   0
    0x10000089c <+4>:   std    31, -8(1)
    0x1000008a0 <+8>:   std    0, 16(1)
    0x1000008a4 <+12>:  stdu   1, -176(1)
    0x1000008a8 <+16>:  mr     31, 1
    0x1000008ac <+20>:  li     3, 0
    0x1000008b0 <+24>:  stw    3, 164(31)
->  0x1000008b4 <+28>:  ld     3, 176(2)
    0x1000008b8 <+32>:  bl     0x100000da8  
    0x1000008bc <+36>:  ld     2, 40(1)
    0x1000008c0 <+40>:  ld     3, 192(2)
    0x1000008c4 <+44>:  addi   4, 31, 140
    0x1000008c8 <+48>:  bl     0x100000dd0  
    0x1000008cc <+52>:  ld     2, 40(1)
    0x1000008d0 <+56>:  lwz    3, 140(31)
    0x1000008d4 <+60>:  extsw  4, 3
    0x1000008d8 <+64>:  addi   3, 31, 144
    0x1000008dc <+68>:  bl     0x1000009a8 
    0x1000008e0 <+72>:  nop    
    0x1000008e4 <+76>:  addi   3, 31, 144
    0x1000008e8 <+80>:  bl     0x100000a88 
    0x1000008ec <+84>:  nop    
    ...
```

With fix:

```
# bin/lldb ../tests/1189804   
(lldb) target create "../tests/1189804"
Current executable set to '/home/dhruv/LLDB/tests/1189804' (powerpc64).
(lldb) b main
Breakpoint 1: where = 1189804`main + 28 at 1189804.c:24, address = 0x00000001000008b4
(lldb) r
Process 27591116 launched: '/home/dhruv/LLDB/tests/1189804' (powerpc64)
Process 27591116 stopped
* thread #1, name = '1189804', stop reason = breakpoint 1.1
    frame #0: 0x00000001000008b4 1189804`main at 1189804.c:24
   21       int choice;
   22  
   23       // Modify and print union data
-> 24       printf("Enter 1 for int, 2 for float, 3 for string: ");
   25       scanf("%d", &choice);
   26       modifyUnion(&data, choice);
   27       printUnion(&data);
(lldb) di
1189804`main:
    0x100000898 <+0>:   mflr   0
    0x10000089c <+4>:   std    31, -8(1)
    0x1000008a0 <+8>:   std    0, 16(1)
    0x1000008a4 <+12>:  stdu   1, -176(1)
    0x1000008a8 <+16>:  mr     31, 1
    0x1000008ac <+20>:  li     3, 0
    0x1000008b0 <+24>:  stw    3, 164(31)
->  0x1000008b4 <+28>:  ld     3, 176(2)
    0x1000008b8 <+32>:  bl     0x100000da8               ; symbol stub for: printf
    0x1000008bc <+36>:  ld     2, 40(1)
    0x1000008c0 <+40>:  ld     3, 192(2)
    0x1000008c4 <+44>:  addi   4, 31, 140
    0x1000008c8 <+48>:  bl     0x100000dd0               ; symbol stub for: scanf
    0x1000008cc <+52>:  ld     2, 40(1)
    0x1000008d0 <+56>:  lwz    3, 140(31)
    0x1000008d4 <+60>:  extsw  4, 3
    0x1000008d8 <+64>:  addi   3, 31, 144
    0x1000008dc <+68>:  bl     0x1000009a8               ; modifyUnion at 1189804.c:63
    0x1000008e0 <+72>:  nop    
    0x1000008e4 <+76>:  addi   3, 31, 144
    0x1000008e8 <+80>:  bl     0x100000a88               ; printUnion at 1189804.c:45
    0x1000008ec <+84>:  nop    
    ...
```