### PR TITLE
cleaning the AIX native files converting from LE to BE

### DIFF
--- a/lldb/source/Plugins/Instruction/PPC64/EmulateInstructionPPC64.cpp
+++ b/lldb/source/Plugins/Instruction/PPC64/EmulateInstructionPPC64.cpp
@@ -11,15 +11,19 @@
 #include <cstdlib>
 #include <optional>
 
-#include "Plugins/Process/Utility/lldb-ppc64le-register-enums.h"
 #include "lldb/Core/PluginManager.h"
 #include "lldb/Symbol/UnwindPlan.h"
 #include "lldb/Utility/ArchSpec.h"
 #include "lldb/Utility/ConstString.h"
 #include "lldb/Utility/LLDBLog.h"
 
+#define DECLARE_REGISTER_INFOS_PPC64_STRUCT
+#include "Plugins/Process/Utility/RegisterInfos_ppc64.h"
+#undef DECLARE_REGISTER_INFOS_PPC64_STRUCT
+
 #define DECLARE_REGISTER_INFOS_PPC64LE_STRUCT
 #include "Plugins/Process/Utility/RegisterInfos_ppc64le.h"
+#undef DECLARE_REGISTER_INFOS_PPC64LE_STRUCT
 
 #include "Plugins/Process/Utility/InstructionUtils.h"
 
@@ -29,7 +33,8 @@ using namespace lldb_private;
 LLDB_PLUGIN_DEFINE_ADV(EmulateInstructionPPC64, InstructionPPC64)
 
 EmulateInstructionPPC64::EmulateInstructionPPC64(const ArchSpec &arch)
-    : EmulateInstruction(arch) {}
+    : EmulateInstruction(arch),
+    m_is_little_endian(arch.GetByteOrder() == eByteOrderLittle) {}
 
 void EmulateInstructionPPC64::Initialize() {
   PluginManager::RegisterPlugin(GetPluginNameStatic(),
@@ -59,10 +64,16 @@ bool EmulateInstructionPPC64::SetTargetTriple(const ArchSpec &arch) {
   return arch.GetTriple().isPPC64();
 }
 
-static std::optional<RegisterInfo> LLDBTableGetRegisterInfo(uint32_t reg_num) {
-  if (reg_num >= std::size(g_register_infos_ppc64le))
-    return {};
-  return g_register_infos_ppc64le[reg_num];
+static std::optional<RegisterInfo> LLDBTableGetRegisterInfo(uint32_t reg_num, bool m_is_le) {
+  if (m_is_le) {
+    if (reg_num >= std::size(g_register_infos_ppc64le)) 
+      return {}; 
+    return g_register_infos_ppc64le[reg_num];
+  } else { 
+    if (reg_num >= std::size(g_register_infos_ppc64)) 
+      return {}; 
+    return g_register_infos_ppc64[reg_num];
+  }
 }
 
 std::optional<RegisterInfo>
@@ -72,7 +83,7 @@ EmulateInstructionPPC64::GetRegisterInfo(RegisterKind reg_kind,
     switch (reg_num) {
     case LLDB_REGNUM_GENERIC_PC:
       reg_kind = eRegisterKindLLDB;
-      reg_num = gpr_pc_ppc64le;
+      reg_num = GetPCRegNum();
       break;
     case LLDB_REGNUM_GENERIC_SP:
       reg_kind = eRegisterKindLLDB;
@@ -80,11 +91,11 @@ EmulateInstructionPPC64::GetRegisterInfo(RegisterKind reg_kind,
       break;
     case LLDB_REGNUM_GENERIC_RA:
       reg_kind = eRegisterKindLLDB;
-      reg_num = gpr_lr_ppc64le;
+      reg_num = GetLRRegNum();
       break;
     case LLDB_REGNUM_GENERIC_FLAGS:
       reg_kind = eRegisterKindLLDB;
-      reg_num = gpr_cr_ppc64le;
+      reg_num = GetCRRegNum();
       break;
 
     default:
@@ -93,7 +104,7 @@ EmulateInstructionPPC64::GetRegisterInfo(RegisterKind reg_kind,
   }
 
   if (reg_kind == eRegisterKindLLDB)
-    return LLDBTableGetRegisterInfo(reg_num);
+    return LLDBTableGetRegisterInfo(reg_num, m_is_little_endian);
   return {};
 }
 
@@ -128,7 +139,7 @@ bool EmulateInstructionPPC64::CreateFunctionEntryUnwind(
   unwind_plan.SetSourcedFromCompiler(eLazyBoolNo);
   unwind_plan.SetUnwindPlanValidAtAllInstructions(eLazyBoolYes);
   unwind_plan.SetUnwindPlanForSignalTrap(eLazyBoolNo);
-  unwind_plan.SetReturnAddressRegister(gpr_lr_ppc64le);
+  unwind_plan.SetReturnAddressRegister(GetLRRegNum());
   return true;
 }
 
@@ -175,6 +186,7 @@ EmulateInstructionPPC64::GetOpcodeForInstruction(uint32_t opcode) {
 }
 
 bool EmulateInstructionPPC64::EvaluateInstruction(uint32_t evaluate_options) {
+
   const uint32_t opcode = m_opcode.GetOpcode32();
   // LLDB_LOG(log, "PPC64::EvaluateInstruction: opcode={0:X+8}", opcode);
   Opcode *opcode_data = GetOpcodeForInstruction(opcode);
@@ -190,7 +202,7 @@ bool EmulateInstructionPPC64::EvaluateInstruction(uint32_t evaluate_options) {
   uint64_t orig_pc_value = 0;
   if (auto_advance_pc) {
     orig_pc_value =
-        ReadRegisterUnsigned(eRegisterKindLLDB, gpr_pc_ppc64le, 0, &success);
+        ReadRegisterUnsigned(eRegisterKindLLDB, GetPCRegNum(), 0, &success);
     if (!success)
       return false;
     LLDB_LOG(GetLog(LLDBLog::Unwind), "orig_pc_value:{0}", orig_pc_value);
@@ -203,7 +215,7 @@ bool EmulateInstructionPPC64::EvaluateInstruction(uint32_t evaluate_options) {
 
   if (auto_advance_pc) {
     uint64_t new_pc_value =
-        ReadRegisterUnsigned(eRegisterKindLLDB, gpr_pc_ppc64le, 0, &success);
+        ReadRegisterUnsigned(eRegisterKindLLDB, GetPCRegNum(), 0, &success);
     if (!success)
       return false;
 
@@ -213,7 +225,7 @@ bool EmulateInstructionPPC64::EvaluateInstruction(uint32_t evaluate_options) {
       EmulateInstruction::Context context;
       context.type = eContextAdvancePC;
       context.SetNoArgs();
-      if (!WriteRegisterUnsigned(context, eRegisterKindLLDB, gpr_pc_ppc64le,
+      if (!WriteRegisterUnsigned(context, eRegisterKindLLDB, GetPCRegNum(),
                                  orig_pc_value + 4))
         return false;
     }
@@ -236,7 +248,7 @@ bool EmulateInstructionPPC64::EmulateMFSPR(uint32_t opcode) {
 
   bool success;
   uint64_t lr =
-      ReadRegisterUnsigned(eRegisterKindLLDB, gpr_lr_ppc64le, 0, &success);
+      ReadRegisterUnsigned(eRegisterKindLLDB, GetLRRegNum(), 0, &success);
   if (!success)
     return false;
   Context context;
@@ -305,10 +317,10 @@ bool EmulateInstructionPPC64::EmulateSTD(uint32_t opcode) {
   uint32_t rs_num = rs;
   if (rs == gpr_r0_ppc64le) {
     uint64_t lr =
-        ReadRegisterUnsigned(eRegisterKindLLDB, gpr_lr_ppc64le, 0, &success);
+        ReadRegisterUnsigned(eRegisterKindLLDB, GetLRRegNum(), 0, &success);
     if (!success || lr != rs_val)
       return false;
-    rs_num = gpr_lr_ppc64le;
+    rs_num = GetLRRegNum();
   }
 
   // set context
@@ -412,10 +424,10 @@ bool EmulateInstructionPPC64::EmulateADDI(uint32_t opcode) {
   LLDB_LOG(log, "EmulateADDI: success!");
 
   // FIX the next-pc
-  uint64_t pc_value = ReadRegisterUnsigned(eRegisterKindLLDB, gpr_pc_ppc64le, 0, &success);
+  uint64_t pc_value = ReadRegisterUnsigned(eRegisterKindLLDB, GetPCRegNum(), 0, &success);
   uint64_t next_pc = pc_value + 4;
   ctx.type = eContextAdjustPC;
-  WriteRegisterUnsigned(ctx, eRegisterKindLLDB, gpr_pc_ppc64le, next_pc);
+  WriteRegisterUnsigned(ctx, eRegisterKindLLDB, GetPCRegNum(), next_pc);
 
   return true;
 }
@@ -427,22 +439,22 @@ bool EmulateInstructionPPC64::EmulateBC(uint32_t opcode) {
   uint64_t target = (uint64_t)target32 + ((target32 & 0x8000) ? 0xffffffffffff0000UL : 0);
   uint32_t BO = Bits32(opcode, 25, 21);
   bool success;
-  uint64_t ctr_value = ReadRegisterUnsigned(eRegisterKindLLDB, gpr_ctr_ppc64le, 0, &success);
+  uint64_t ctr_value = ReadRegisterUnsigned(eRegisterKindLLDB, GetCTRRegNum(), 0, &success);
   if ((~BO) & (1U << 2))
     ctr_value = ctr_value - 1;
   bool ctr_ok = (bool)(BO & (1U << 2)) | ((bool)(ctr_value != 0) ^ (bool)(BO & (1U << 1)));
-  uint64_t cr_value = ReadRegisterUnsigned(eRegisterKindLLDB, gpr_cr_ppc64le, 0, &success);
+  uint64_t cr_value = ReadRegisterUnsigned(eRegisterKindLLDB, GetCRRegNum(), 0, &success);
   uint32_t BI = Bits32(opcode, 20, 16);
   bool cond_ok = (bool)(BO & (1U << 4)) | (bool)(((cr_value >> (63 - (BI + 32))) & 1U) == ((BO >> 3) & 1U));
 
-  uint64_t pc_value = ReadRegisterUnsigned(eRegisterKindLLDB, gpr_pc_ppc64le, 0, &success);
+  uint64_t pc_value = ReadRegisterUnsigned(eRegisterKindLLDB, GetPCRegNum(), 0, &success);
   uint64_t next_pc = pc_value + 4;
   if (ctr_ok & cond_ok)
     next_pc = pc_value + target;
 
   Context ctx;
   ctx.type = eContextAdjustPC;
-  WriteRegisterUnsigned(ctx, eRegisterKindLLDB, gpr_pc_ppc64le, next_pc);
+  WriteRegisterUnsigned(ctx, eRegisterKindLLDB, GetPCRegNum(), next_pc);
   Log *log = GetLog(LLDBLog::Unwind);
   LLDB_LOG(log, "EmulateBC: success!");
   return true;
@@ -455,22 +467,22 @@ bool EmulateInstructionPPC64::EmulateBCA(uint32_t opcode) {
   uint64_t target = (uint64_t)target32 + ((target32 & 0x8000) ? 0xffffffffffff0000UL : 0);
   uint32_t BO = Bits32(opcode, 25, 21);
   bool success;
-  uint64_t ctr_value = ReadRegisterUnsigned(eRegisterKindLLDB, gpr_ctr_ppc64le, 0, &success);
+  uint64_t ctr_value = ReadRegisterUnsigned(eRegisterKindLLDB, GetCTRRegNum(), 0, &success);
   if ((~BO) & (1U << 2))
     ctr_value = ctr_value - 1;
   bool ctr_ok = (bool)(BO & (1U << 2)) | ((bool)(ctr_value != 0) ^ (bool)(BO & (1U << 1)));
-  uint64_t cr_value = ReadRegisterUnsigned(eRegisterKindLLDB, gpr_cr_ppc64le, 0, &success);
+  uint64_t cr_value = ReadRegisterUnsigned(eRegisterKindLLDB, GetCRRegNum(), 0, &success);
   uint32_t BI = Bits32(opcode, 20, 16);
   bool cond_ok = (bool)(BO & (1U << 4)) | (bool)(((cr_value >> (63 - (BI + 32))) & 1U) == ((BO >> 3) & 1U));
 
-  uint64_t pc_value = ReadRegisterUnsigned(eRegisterKindLLDB, gpr_pc_ppc64le, 0, &success);
+  uint64_t pc_value = ReadRegisterUnsigned(eRegisterKindLLDB, GetPCRegNum(), 0, &success);
   uint64_t next_pc = pc_value + 4;
   if (ctr_ok & cond_ok)
     next_pc = target;
 
   Context ctx;
   ctx.type = eContextAdjustPC;
-  WriteRegisterUnsigned(ctx, eRegisterKindLLDB, gpr_pc_ppc64le, next_pc);
+  WriteRegisterUnsigned(ctx, eRegisterKindLLDB, GetPCRegNum(), next_pc);
   Log *log = GetLog(LLDBLog::Unwind);
   LLDB_LOG(log, "EmulateBCA: success!");
   return true;
@@ -481,24 +493,24 @@ bool EmulateInstructionPPC64::EmulateBCLR(uint32_t opcode) {
   uint32_t M = 0;
   uint32_t BO = Bits32(opcode, 25, 21);
   bool success;
-  uint64_t ctr_value = ReadRegisterUnsigned(eRegisterKindLLDB, gpr_ctr_ppc64le, 0, &success);
+  uint64_t ctr_value = ReadRegisterUnsigned(eRegisterKindLLDB, GetCTRRegNum(), 0, &success);
   if ((~BO) & (1U << 2))
     ctr_value = ctr_value - 1;
   bool ctr_ok = (bool)(BO & (1U << 2)) | ((bool)(ctr_value != 0) ^ (bool)(BO & (1U << 1)));
-  uint64_t cr_value = ReadRegisterUnsigned(eRegisterKindLLDB, gpr_cr_ppc64le, 0, &success);
+  uint64_t cr_value = ReadRegisterUnsigned(eRegisterKindLLDB, GetCRRegNum(), 0, &success);
   uint32_t BI = Bits32(opcode, 20, 16);
   bool cond_ok = (bool)(BO & (1U << 4)) | (bool)(((cr_value >> (63 - (BI + 32))) & 1U) == ((BO >> 3) & 1U));
 
-  uint64_t pc_value = ReadRegisterUnsigned(eRegisterKindLLDB, gpr_pc_ppc64le, 0, &success);
+  uint64_t pc_value = ReadRegisterUnsigned(eRegisterKindLLDB, GetPCRegNum(), 0, &success);
   uint64_t next_pc = pc_value + 4;
   if (ctr_ok & cond_ok) {
-    next_pc = ReadRegisterUnsigned(eRegisterKindLLDB, gpr_lr_ppc64le, 0, &success);
+    next_pc = ReadRegisterUnsigned(eRegisterKindLLDB, GetLRRegNum(), 0, &success);
     next_pc &= ~((1UL << 2) - 1);
   }
 
   Context ctx;
   ctx.type = eContextAdjustPC;
-  WriteRegisterUnsigned(ctx, eRegisterKindLLDB, gpr_pc_ppc64le, next_pc);
+  WriteRegisterUnsigned(ctx, eRegisterKindLLDB, GetPCRegNum(), next_pc);
   Log *log = GetLog(LLDBLog::Unwind);
   LLDB_LOG(log, "EmulateBCLR: success!");
   return true;
@@ -509,25 +521,25 @@ bool EmulateInstructionPPC64::EmulateBCCTR(uint32_t opcode) {
   uint32_t M = 0;
   uint32_t BO = Bits32(opcode, 25, 21);
   bool success;
-  uint64_t cr_value = ReadRegisterUnsigned(eRegisterKindLLDB, gpr_cr_ppc64le, 0, &success);
+  uint64_t cr_value = ReadRegisterUnsigned(eRegisterKindLLDB, GetCRRegNum(), 0, &success);
   uint32_t BI = Bits32(opcode, 20, 16);
   bool cond_ok = (bool)(BO & (1U << 4)) | (bool)(((cr_value >> (63 - (BI + 32))) & 1U) == ((BO >> 3) & 1U));
 
   Log *log = GetLog(LLDBLog::Unwind);
-  uint64_t pc_value = ReadRegisterUnsigned(eRegisterKindLLDB, gpr_pc_ppc64le, 0, &success);
+  uint64_t pc_value = ReadRegisterUnsigned(eRegisterKindLLDB, GetPCRegNum(), 0, &success);
   uint64_t next_pc = pc_value + 4;
   if (cond_ok) {
-    next_pc = ReadRegisterUnsigned(eRegisterKindLLDB, gpr_ctr_ppc64le, 0, &success);
+    next_pc = ReadRegisterUnsigned(eRegisterKindLLDB, GetCTRRegNum(), 0, &success);
     next_pc &= ~((1UL << 2) - 1);
     if (next_pc < 0x4000000) {
-      LLDB_LOGF(log, "EmulateBCCTR: next address %lx out of range, emulate by goto LR!");
-      next_pc = ReadRegisterUnsigned(eRegisterKindLLDB, gpr_lr_ppc64le, 0, &success);
+      LLDB_LOGF(log, "EmulateBCCTR: next address %lx out of range, emulate by goto LR!", next_pc);
+      next_pc = ReadRegisterUnsigned(eRegisterKindLLDB, GetLRRegNum(), 0, &success);
     }
   }
 
   Context ctx;
   ctx.type = eContextAdjustPC;
-  WriteRegisterUnsigned(ctx, eRegisterKindLLDB, gpr_pc_ppc64le, next_pc);
+  WriteRegisterUnsigned(ctx, eRegisterKindLLDB, GetPCRegNum(), next_pc);
   LLDB_LOG(log, "EmulateBCCTR: success!");
   return true;
 }
@@ -544,12 +556,12 @@ bool EmulateInstructionPPC64::EmulateB(uint32_t opcode) {
   uint64_t target = (uint64_t)target32 + ((target32 & 0x2000000) ? 0xfffffffffc000000UL : 0);
 
   bool success;
-  uint64_t pc_value = ReadRegisterUnsigned(eRegisterKindLLDB, gpr_pc_ppc64le, 0, &success);
+  uint64_t pc_value = ReadRegisterUnsigned(eRegisterKindLLDB, GetPCRegNum(), 0, &success);
   uint64_t next_pc = pc_value + target;
 
   Context ctx;
   ctx.type = eContextAdjustPC;
-  WriteRegisterUnsigned(ctx, eRegisterKindLLDB, gpr_pc_ppc64le, next_pc);
+  WriteRegisterUnsigned(ctx, eRegisterKindLLDB, GetPCRegNum(), next_pc);
   Log *log = GetLog(LLDBLog::Unwind);
   LLDB_LOG(log, "EmulateB: success!");
   return true;
@@ -559,11 +571,11 @@ bool EmulateInstructionPPC64::EmulateBA(uint32_t opcode) {
   Log *log = GetLog(LLDBLog::Unwind);
 
   bool success;
-  uint64_t next_pc = ReadRegisterUnsigned(eRegisterKindLLDB, gpr_lr_ppc64le, 0, &success);
+  uint64_t next_pc = ReadRegisterUnsigned(eRegisterKindLLDB, GetLRRegNum(), 0, &success);
 
   Context ctx;
   ctx.type = eContextAdjustPC;
-  WriteRegisterUnsigned(ctx, eRegisterKindLLDB, gpr_pc_ppc64le, next_pc);
+  WriteRegisterUnsigned(ctx, eRegisterKindLLDB, GetPCRegNum(), next_pc);
   LLDB_LOG(log, "EmulateBA: emulate by branch to lr!");
   return true;
 }
@@ -572,12 +584,12 @@ bool EmulateInstructionPPC64::EmulateBLA(uint32_t opcode) {
   Log *log = GetLog(LLDBLog::Unwind);
 
   bool success;
-  uint64_t pc_value = ReadRegisterUnsigned(eRegisterKindLLDB, gpr_pc_ppc64le, 0, &success);
+  uint64_t pc_value = ReadRegisterUnsigned(eRegisterKindLLDB, GetPCRegNum(), 0, &success);
   uint64_t next_pc = pc_value + 4;
 
   Context ctx;
   ctx.type = eContextAdjustPC;
-  WriteRegisterUnsigned(ctx, eRegisterKindLLDB, gpr_pc_ppc64le, next_pc);
+  WriteRegisterUnsigned(ctx, eRegisterKindLLDB, GetPCRegNum(), next_pc);
   LLDB_LOG(log, "EmulateBLA: emulate by branch to lr!");
   return true;
 }

--- a/lldb/source/Plugins/Instruction/PPC64/EmulateInstructionPPC64.h
+++ b/lldb/source/Plugins/Instruction/PPC64/EmulateInstructionPPC64.h
@@ -9,6 +9,8 @@
 #ifndef LLDB_SOURCE_PLUGINS_INSTRUCTION_PPC64_EMULATEINSTRUCTIONPPC64_H
 #define LLDB_SOURCE_PLUGINS_INSTRUCTION_PPC64_EMULATEINSTRUCTIONPPC64_H
 
+#include "Plugins/Process/Utility/lldb-ppc64-register-enums.h"
+#include "Plugins/Process/Utility/lldb-ppc64le-register-enums.h"
 #include "lldb/Core/EmulateInstruction.h"
 #include "lldb/Interpreter/OptionValue.h"
 #include "lldb/Utility/Log.h"
@@ -73,6 +75,18 @@ public:
 
   bool CreateFunctionEntryUnwind(UnwindPlan &unwind_plan) override;
 
+  uint32_t GetPCRegNum() const {
+      return m_is_little_endian ? gpr_pc_ppc64le : gpr_pc_ppc64; }
+
+  uint32_t GetLRRegNum() const {
+      return m_is_little_endian ? gpr_lr_ppc64le : gpr_lr_ppc64; }
+
+  uint32_t GetCRRegNum() const {
+      return m_is_little_endian ? gpr_cr_ppc64le : gpr_cr_ppc64; }
+
+  uint32_t GetCTRRegNum() const {
+      return m_is_little_endian ? gpr_ctr_ppc64le : gpr_ctr_ppc64; }
+
 private:
   struct Opcode {
     uint32_t mask;
@@ -98,6 +112,8 @@ private:
   bool EmulateBCLR(uint32_t opcode);
   bool EmulateBCCTR(uint32_t opcode);
   bool EmulateBCTAR(uint32_t opcode);
+
+  bool m_is_little_endian; 
 };
 
 } // namespace lldb_private

--- a/lldb/source/Plugins/Process/AIX/NativeRegisterContextAIX_ppc64.h
+++ b/lldb/source/Plugins/Process/AIX/NativeRegisterContextAIX_ppc64.h
@@ -11,15 +11,15 @@
 
 #if defined(__powerpc64__)
 
-#ifndef lldb_NativeRegisterContextAIX_ppc64_h
-#define lldb_NativeRegisterContextAIX_ppc64_h
+#ifndef LLDB_SOURCE_PLUGINS_PROCESS_AIX_NATIVEREGISTERCONTEXTAIX_PPC64_H
+#define LLDB_SOURCE_PLUGINS_PROCESS_AIX_NATIVEREGISTERCONTEXTAIX_PPC64_H
 
 #include "Plugins/Process/AIX/NativeRegisterContextAIX.h"
-#include "Plugins/Process/Utility/lldb-ppc64le-register-enums.h"
+#include "Plugins/Process/Utility/lldb-ppc64-register-enums.h"
 
-#define DECLARE_REGISTER_INFOS_PPC64LE_STRUCT
-#include "Plugins/Process/Utility/RegisterInfos_ppc64le.h"
-#undef DECLARE_REGISTER_INFOS_PPC64LE_STRUCT
+#define DECLARE_REGISTER_INFOS_PPC64_STRUCT
+#include "Plugins/Process/Utility/RegisterInfos_ppc64.h"
+#undef DECLARE_REGISTER_INFOS_PPC64_STRUCT
 
 namespace lldb_private {
 namespace process_aix {
@@ -80,17 +80,17 @@ protected:
 
   Status WriteVSX();
 
-  void *GetGPRBuffer() override { return &m_gpr_ppc64le; }
+  void *GetGPRBuffer() override { return &m_gpr_ppc64; }
 
-  void *GetFPRBuffer() override { return &m_fpr_ppc64le; }
+  void *GetFPRBuffer() override { return &m_fpr_ppc64; }
 
-  size_t GetFPRSize() override { return sizeof(m_fpr_ppc64le); }
+  size_t GetFPRSize() override { return sizeof(m_fpr_ppc64); }
 
 private:
-  GPR m_gpr_ppc64le; // 64-bit general purpose registers.
-  FPR m_fpr_ppc64le; // floating-point registers including extended register.
-  VMX m_vmx_ppc64le; // VMX registers.
-  VSX m_vsx_ppc64le; // Last lower bytes from first VSX registers.
+  GPR_PPC64 m_gpr_ppc64; // 64-bit general purpose registers.
+  FPR_PPC64 m_fpr_ppc64; // floating-point registers including extended register.
+  VMX_PPC64 m_vmx_ppc64; // VMX registers.
+  VSX_PPC64 m_vsx_ppc64; // Last lower bytes from first VSX registers.
 
   bool IsGPR(unsigned reg) const;
 
@@ -133,6 +133,6 @@ private:
 } // namespace process_aix
 } // namespace lldb_private
 
-#endif // #ifndef lldb_NativeRegisterContextAIX_ppc64_h
+#endif // #ifndef LLDB_SOURCE_PLUGINS_PROCESS_AIX_NATIVEREGISTECONTXTAIX_PPC64_H 
 
 #endif // defined(__powerpc64__)

--- a/lldb/source/Plugins/Process/Utility/CMakeLists.txt
+++ b/lldb/source/Plugins/Process/Utility/CMakeLists.txt
@@ -60,6 +60,7 @@ add_lldb_library(lldbPluginProcessUtility
   RegisterInfoPOSIX_arm64.cpp
   RegisterInfoPOSIX_loongarch64.cpp
   RegisterInfoPOSIX_ppc64le.cpp
+  RegisterInfoPOSIX_ppc64.cpp
   RegisterInfoPOSIX_riscv32.cpp
   RegisterInfoPOSIX_riscv64.cpp
   StopInfoMachException.cpp

--- a/lldb/source/Plugins/Process/Utility/RegisterInfoPOSIX_ppc64.cpp
+++ b/lldb/source/Plugins/Process/Utility/RegisterInfoPOSIX_ppc64.cpp
@@ -1,0 +1,63 @@
+//===-- RegisterInfoPOSIX_ppc64.cpp ---------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <cassert>
+#include <cstddef>
+#include <vector>
+
+#include "lldb/lldb-defines.h"
+#include "llvm/Support/Compiler.h"
+
+#include "RegisterInfoPOSIX_ppc64.h"
+
+// Include RegisterInfoPOSIX_ppc64 to declare our g_register_infos_ppc64
+#define DECLARE_REGISTER_INFOS_PPC64_STRUCT
+#include "RegisterInfos_ppc64.h"
+#undef DECLARE_REGISTER_INFOS_PPC64_STRUCT
+
+static const lldb_private::RegisterInfo *
+GetRegisterInfoPtr(const lldb_private::ArchSpec &target_arch) {
+  switch (target_arch.GetMachine()) {
+  case llvm::Triple::ppc64:
+    return g_register_infos_ppc64;
+  default:
+    assert(false && "Unhandled target architecture.");
+    return nullptr;
+  }
+}
+
+static uint32_t
+GetRegisterInfoCount(const lldb_private::ArchSpec &target_arch) {
+  switch (target_arch.GetMachine()) {
+  case llvm::Triple::ppc64:
+    return static_cast<uint32_t>(sizeof(g_register_infos_ppc64) /
+                                 sizeof(g_register_infos_ppc64[0]));
+  default:
+    assert(false && "Unhandled target architecture.");
+    return 0;
+  }
+}
+
+RegisterInfoPOSIX_ppc64::RegisterInfoPOSIX_ppc64(
+    const lldb_private::ArchSpec &target_arch)
+    : lldb_private::RegisterInfoInterface(target_arch),
+      m_register_info_p(GetRegisterInfoPtr(target_arch)),
+      m_register_info_count(GetRegisterInfoCount(target_arch)) {}
+
+size_t RegisterInfoPOSIX_ppc64::GetGPRSize() const {
+  return sizeof(GPR_PPC64);
+}
+
+const lldb_private::RegisterInfo *
+RegisterInfoPOSIX_ppc64::GetRegisterInfo() const {
+  return m_register_info_p;
+}
+
+uint32_t RegisterInfoPOSIX_ppc64::GetRegisterCount() const {
+  return m_register_info_count;
+}

--- a/lldb/source/Plugins/Process/Utility/RegisterInfoPOSIX_ppc64.h
+++ b/lldb/source/Plugins/Process/Utility/RegisterInfoPOSIX_ppc64.h
@@ -1,0 +1,31 @@
+//===-- RegisterInfoPOSIX_ppc64.h -------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLDB_SOURCE_PLUGINS_PROCESS_UTILITY_REGISTERINFOPOSIX_PPC64_H
+#define LLDB_SOURCE_PLUGINS_PROCESS_UTILITY_REGISTERINFOPOSIX_PPC64_H
+
+#include "RegisterInfoInterface.h"
+#include "lldb/Target/RegisterContext.h"
+#include "lldb/lldb-private.h"
+
+class RegisterInfoPOSIX_ppc64 : public lldb_private::RegisterInfoInterface {
+public:
+  RegisterInfoPOSIX_ppc64(const lldb_private::ArchSpec &target_arch);
+
+  size_t GetGPRSize() const override;
+
+  const lldb_private::RegisterInfo *GetRegisterInfo() const override;
+
+  uint32_t GetRegisterCount() const override;
+
+private:
+  const lldb_private::RegisterInfo *m_register_info_p;
+  uint32_t m_register_info_count;
+};
+
+#endif // #ifndef LLDB_SOURCE_PLUGINS_PROCESS_UTILITY_REGISTERINFOPOSIX_PPC64_H


### PR DESCRIPTION
- This commit updates AIX-specific native files from Little Endian (LE) to Big Endian (BE). This ensures that the AIX implementation uses the correct byte order and maintains consistency across the system.