### PR TITLE
Add version details specific to AIX

### DIFF
--- a/lldb/source/Version/Version.cpp
+++ b/lldb/source/Version/Version.cpp
@@ -11,6 +11,8 @@
 #include "lldb/Version/Version.inc"
 #include "clang/Basic/Version.h"
 
+const char *aix_version_string = " AIX pre-release VRMF: 21.1.3.1";
+
 static const char *GetLLDBVersion() {
 #ifdef LLDB_FULL_VERSION_STRING
   return LLDB_FULL_VERSION_STRING;
@@ -42,6 +44,10 @@ const char *lldb_private::GetVersion() {
     const char *lldb_version = GetLLDBVersion();
     const char *lldb_repo = GetLLDBRepository();
     const char *lldb_rev = GetLLDBRevision();
+#ifdef _AIX
+    g_version_str += aix_version_string;
+    g_version_str += "\n ";
+#endif
     g_version_str += lldb_version;
     if (lldb_repo || lldb_rev) {
       g_version_str += " (";

--- a/lldb/source/Version/Version.cpp
+++ b/lldb/source/Version/Version.cpp
@@ -11,7 +11,7 @@
 #include "lldb/Version/Version.inc"
 #include "clang/Basic/Version.h"
 
-const char *aix_version_string = " AIX pre-release VRMF: 21.1.3.1";
+const char *aix_version_string = " AIX pre-release VRMF: 21.1.3.1 \n";
 
 static const char *GetLLDBVersion() {
 #ifdef LLDB_FULL_VERSION_STRING
@@ -46,7 +46,6 @@ const char *lldb_private::GetVersion() {
     const char *lldb_rev = GetLLDBRevision();
 #ifdef _AIX
     g_version_str += aix_version_string;
-    g_version_str += "\n ";
 #endif
     g_version_str += lldb_version;
     if (lldb_repo || lldb_rev) {

--- a/lldb/source/Version/Version.cpp
+++ b/lldb/source/Version/Version.cpp
@@ -11,7 +11,7 @@
 #include "lldb/Version/Version.inc"
 #include "clang/Basic/Version.h"
 
-const char *aix_version_string = " AIX pre-release VRMF: 21.1.3.1 \n";
+const char *aix_version_string = " AIX pre-release VRMF: 21.1.3.2 \n";
 
 static const char *GetLLDBVersion() {
 #ifdef LLDB_FULL_VERSION_STRING


### PR DESCRIPTION
Added aix specific version update for `lldb --version`
`AIX pre-release VRMF: 21.1.3.1`
It will be updated for every pre-release and release.