### PR TITLE
Aix 32bit support

### DIFF
--- a/lldb/include/lldb/Core/EmulateInstruction.h
+++ b/lldb/include/lldb/Core/EmulateInstruction.h
@@ -556,7 +556,7 @@ protected:
 private:
   virtual BreakpointLocationsPredictorCreator
   GetSingleStepBreakpointLocationsPredictorCreator() {
-    if (!m_arch.IsMIPS() && !m_arch.GetTriple().isPPC64() &&
+    if (!m_arch.IsMIPS() && !m_arch.GetTriple().isPPC() &&
         !m_arch.GetTriple().isLoongArch()) {
       // Unsupported architecture
       return [](std::unique_ptr<EmulateInstruction> emulator_up) {

--- a/lldb/source/Host/aix/Host.cpp
+++ b/lldb/source/Host/aix/Host.cpp
@@ -17,6 +17,14 @@
 #include <sys/proc.h>
 #include <sys/procfs.h>
 
+#include "lldb/Host/FileSystem.h"
+#include "llvm/Object/ObjectFile.h"
+#include "llvm/Object/XCOFFObjectFile.h"
+#include "llvm/Support/Error.h"
+#include "llvm/Support/MemoryBuffer.h"
+
+using namespace llvm;
+using namespace llvm::object;
 using namespace lldb;
 using namespace lldb_private;
 
@@ -81,6 +89,35 @@ static bool GetStatusInfo(::pid_t pid, ProcessInstanceInfo &processInfo,
   return true;
 }
 
+static bool GetXCOFFProcessType(llvm::StringRef exe_path) {
+  Log *log = GetLog(LLDBLog::Host);
+
+  auto file_buffer = MemoryBuffer::getFile(exe_path);
+  if (!file_buffer) {
+    LLDB_LOG(log, "Failed to open file: {0}", exe_path);
+    return false;
+  }
+
+  llvm::Expected<std::unique_ptr<llvm::object::ObjectFile>> obj_or_err =
+      llvm::object::ObjectFile::createObjectFile(
+          (*file_buffer)->getMemBufferRef());
+
+  if (!obj_or_err)
+    return false;
+
+  llvm::object::ObjectFile *obj = obj_or_err->get();
+
+  // Check if it's an XCOFF binary
+  const llvm::object::XCOFFObjectFile *xcoff_obj =
+      llvm::dyn_cast<llvm::object::XCOFFObjectFile>(obj);
+  if (!xcoff_obj) {
+    LLDB_LOG(log, "Not an XCOFF object file: {0}", exe_path);
+    return false;
+  }
+
+  return xcoff_obj->is64Bit();
+}
+
 static bool GetExePathAndIds(::pid_t pid, ProcessInstanceInfo &process_info) {
   struct psinfo psinfoData;
   auto BufferOrError = getProcFile(pid, "psinfo");
@@ -101,8 +138,13 @@ static bool GetExePathAndIds(::pid_t pid, ProcessInstanceInfo &process_info) {
 
   process_info.GetExecutableFile().SetFile(PathRef, FileSpec::Style::native);
   ArchSpec arch_spec = ArchSpec();
-  arch_spec.SetArchitecture(eArchTypeXCOFF, llvm::XCOFF::TCPU_PPC64,
-                            LLDB_INVALID_CPUTYPE, llvm::Triple::AIX);
+
+  bool is64Bit = GetXCOFFProcessType(PathRef);
+  const uint32_t cpu_type =
+      is64Bit ? llvm::XCOFF::TCPU_PPC64 : llvm::XCOFF::TCPU_PPC;
+
+  arch_spec.SetArchitecture(eArchTypeXCOFF, cpu_type, LLDB_INVALID_CPUTYPE,
+                            llvm::Triple::AIX);
   process_info.SetArchitecture(arch_spec);
   process_info.SetParentProcessID(psinfoData.pr_ppid);
   process_info.SetGroupID(psinfoData.pr_gid);

--- a/lldb/source/Plugins/ABI/PowerPC/ABISysV_ppc.cpp
+++ b/lldb/source/Plugins/ABI/PowerPC/ABISysV_ppc.cpp
@@ -31,6 +31,10 @@
 #include "lldb/ValueObject/ValueObjectRegister.h"
 #include <optional>
 
+#define DECLARE_REGISTER_INFOS_PPC64_STRUCT
+#include "Plugins/Process/Utility/RegisterInfos_ppc64.h"
+#undef DECLARE_REGISTER_INFOS_PPC64_STRUCT
+
 using namespace lldb;
 using namespace lldb_private;
 
@@ -210,8 +214,13 @@ static const uint32_t k_num_register_infos = std::size(g_register_infos);
 
 const lldb_private::RegisterInfo *
 ABISysV_ppc::GetRegisterInfoArray(uint32_t &count) {
+#ifdef _AIX
+  count = std::size(g_register_infos_ppc);
+  return g_register_infos_ppc;
+#else
   count = k_num_register_infos;
   return g_register_infos;
+#endif
 }
 
 size_t ABISysV_ppc::GetRedZoneSize() const { return 224; }
@@ -304,6 +313,95 @@ bool ABISysV_ppc::PrepareTrivialCall(Thread &thread, addr_t sp,
   LLDB_LOGF(log, "Writing IP: 0x%" PRIx64, (uint64_t)func_addr);
 
   if (!reg_ctx->WriteRegisterFromUnsigned(pc_reg_info, func_addr))
+    return false;
+
+  return true;
+}
+
+bool ABISysV_ppc::PrepareTrivialCall(Thread &thread, addr_t sp,
+                                     addr_t func_addr, addr_t toc_addr,
+                                     addr_t return_addr,
+                                     llvm::ArrayRef<addr_t> args) const {
+  Log *log = GetLog(LLDBLog::Expressions);
+
+  if (log) {
+    StreamString s;
+    s.Printf("ABISysV_ppc::PrepareTrivialCall (tid = 0x%" PRIx64
+             ", sp = 0x%" PRIx64 ", func_addr = 0x%" PRIx64
+             ", return_addr = 0x%" PRIx64 ", toc_addr = 0x%" PRIx64,
+             thread.GetID(), (uint64_t)sp, (uint64_t)func_addr,
+             (uint64_t)return_addr, (uint64_t)toc_addr);
+
+    for (size_t i = 0; i < args.size(); ++i)
+      s.Printf(", arg%" PRIu64 " = 0x%" PRIx64, static_cast<uint64_t>(i + 1),
+               args[i]);
+    s.PutCString(")");
+    log->PutString(s.GetString());
+  }
+
+  RegisterContext *reg_ctx = thread.GetRegisterContext().get();
+  if (!reg_ctx)
+    return false;
+
+  const RegisterInfo *reg_info = nullptr;
+
+  if (args.size() > 8) // TODO handle more than 8 arguments
+    return false;
+
+  for (size_t i = 0; i < args.size(); ++i) {
+    reg_info = reg_ctx->GetRegisterInfo(eRegisterKindGeneric,
+                                        LLDB_REGNUM_GENERIC_ARG1 + i);
+    LLDB_LOGF(log, "About to write arg%" PRIu64 " (0x%" PRIx64 ") into %s",
+              static_cast<uint64_t>(i + 1), args[i], reg_info->name);
+    if (!reg_ctx->WriteRegisterFromUnsigned(reg_info, args[i]))
+      return false;
+  }
+
+  // First, align the SP
+
+  LLDB_LOGF(log, "16-byte aligning SP: 0x%" PRIx64 " to 0x%" PRIx64,
+            (uint64_t)sp, (uint64_t)(sp & ~0xfull));
+
+  sp &= ~(0xfull); // 16-byte alignment
+
+  sp -= 8;
+
+  Status error;
+  const RegisterInfo *pc_reg_info =
+      reg_ctx->GetRegisterInfo(eRegisterKindGeneric, LLDB_REGNUM_GENERIC_PC);
+  const RegisterInfo *sp_reg_info =
+      reg_ctx->GetRegisterInfo(eRegisterKindGeneric, LLDB_REGNUM_GENERIC_SP);
+  ProcessSP process_sp(thread.GetProcess());
+
+  const RegisterInfo *r2_reg_info = reg_ctx->GetRegisterInfoAtIndex(2);
+
+  RegisterValue reg_value;
+
+  LLDB_LOGF(log,
+            "Pushing the return address onto the stack: 0x%" PRIx64
+            ": 0x%" PRIx64,
+            (uint64_t)sp, (uint64_t)return_addr);
+
+  // Save return address onto the stack
+  if (!process_sp->WritePointerToMemory(sp, return_addr, error))
+    return false;
+
+  // %r1 is set to the actual stack value.
+
+  LLDB_LOGF(log, "Writing SP: 0x%" PRIx64, (uint64_t)sp);
+
+  if (!reg_ctx->WriteRegisterFromUnsigned(sp_reg_info, sp))
+    return false;
+
+  // %pc is set to the address of the called function.
+
+  LLDB_LOGF(log, "Writing IP: 0x%" PRIx64, (uint64_t)func_addr);
+
+  if (!reg_ctx->WriteRegisterFromUnsigned(pc_reg_info, func_addr))
+    return false;
+
+  LLDB_LOGF(log, "Writing R2: 0x%" PRIx64, (uint64_t)toc_addr);
+  if (!reg_ctx->WriteRegisterFromUnsigned(r2_reg_info, toc_addr)) 
     return false;
 
   return true;

--- a/lldb/source/Plugins/ABI/PowerPC/ABISysV_ppc.h
+++ b/lldb/source/Plugins/ABI/PowerPC/ABISysV_ppc.h
@@ -23,6 +23,11 @@ public:
                           lldb::addr_t returnAddress,
                           llvm::ArrayRef<lldb::addr_t> args) const override;
 
+  bool PrepareTrivialCall(lldb_private::Thread &thread, lldb::addr_t sp,
+                          lldb::addr_t functionAddress,
+                          lldb::addr_t tocAddress,
+                          lldb::addr_t returnAddress,
+                          llvm::ArrayRef<lldb::addr_t> args) const override;
   bool GetArgumentValues(lldb_private::Thread &thread,
                          lldb_private::ValueList &values) const override;
 

--- a/lldb/source/Plugins/Instruction/PPC64/EmulateInstructionPPC64.cpp
+++ b/lldb/source/Plugins/Instruction/PPC64/EmulateInstructionPPC64.cpp
@@ -34,7 +34,8 @@ LLDB_PLUGIN_DEFINE_ADV(EmulateInstructionPPC64, InstructionPPC64)
 
 EmulateInstructionPPC64::EmulateInstructionPPC64(const ArchSpec &arch)
     : EmulateInstruction(arch),
-    m_is_little_endian(arch.GetByteOrder() == eByteOrderLittle) {}
+      m_is_little_endian(arch.GetByteOrder() == eByteOrderLittle),
+      m_is_64bit(arch.GetTriple().isPPC64()) {}
 
 void EmulateInstructionPPC64::Initialize() {
   PluginManager::RegisterPlugin(GetPluginNameStatic(),
@@ -64,16 +65,23 @@ bool EmulateInstructionPPC64::SetTargetTriple(const ArchSpec &arch) {
   return arch.GetTriple().isPPC();
 }
 
-static std::optional<RegisterInfo> LLDBTableGetRegisterInfo(uint32_t reg_num, bool m_is_le) {
-  if (m_is_le) {
-    if (reg_num >= std::size(g_register_infos_ppc64le)) 
-      return {}; 
+static std::optional<RegisterInfo>
+LLDBTableGetRegisterInfo(uint32_t reg_num, bool is_le, bool is_64b) {
+  if (is_le) {
+    if (reg_num >= std::size(g_register_infos_ppc64le))
+      return std::nullopt;
     return g_register_infos_ppc64le[reg_num];
-  } else { 
-    if (reg_num >= std::size(g_register_infos_ppc64)) 
-      return {}; 
+  }
+
+  if (is_64b) {
+    if (reg_num >= std::size(g_register_infos_ppc64))
+      return std::nullopt;
     return g_register_infos_ppc64[reg_num];
   }
+
+  if (reg_num >= std::size(g_register_infos_ppc))
+    return std::nullopt;
+  return g_register_infos_ppc[reg_num];
 }
 
 std::optional<RegisterInfo>
@@ -104,7 +112,7 @@ EmulateInstructionPPC64::GetRegisterInfo(RegisterKind reg_kind,
   }
 
   if (reg_kind == eRegisterKindLLDB)
-    return LLDBTableGetRegisterInfo(reg_num, m_is_little_endian);
+    return LLDBTableGetRegisterInfo(reg_num, m_is_little_endian, m_is_64bit);
   return {};
 }
 
@@ -158,22 +166,31 @@ EmulateInstructionPPC64::GetOpcodeForInstruction(uint32_t opcode) {
        "addi RT, RA, SI"},
       {0xfc000003, 0xe8000000, &EmulateInstructionPPC64::EmulateLD,
        "ld RT, DS(RA)"},
-//      {0xffff0003, 0x40820000, &EmulateInstructionPPC64::EmulateBNE,
-//       "bne TARGET"},
-      {0xfc000002, 0x48000000, &EmulateInstructionPPC64::EmulateB,
-       "b TARGET"},
-      {0xfc000003, 0x48000002, &EmulateInstructionPPC64::EmulateBA,
-       "ba TARGET"},
-      {0xfc000003, 0x48000003, &EmulateInstructionPPC64::EmulateBLA,
+      {0xfc000000, 0x90000000, &EmulateInstructionPPC64::EmulateSTW,
+       "stw RS, DS(RA)"},
+      {0xfc000000, 0x94000000, &EmulateInstructionPPC64::EmulateSTW,
+       "stwu RS, DS(RA)"},
+      {0xfc000003, 0x48000000, &EmulateInstructionPPC64::EmulateB, "b TARGET"},
+      {0xfc000003, 0x48000001, &EmulateInstructionPPC64::EmulateB, "bl TARGET"},
+      {0xfc000003, 0x48000002, &EmulateInstructionPPC64::EmulateB, "ba TARGET"},
+      {0xfc000003, 0x48000003, &EmulateInstructionPPC64::EmulateB,
        "bla TARGET"},
-      {0xfc000002, 0x40000000, &EmulateInstructionPPC64::EmulateBC,
+      {0xfc000003, 0x40000000, &EmulateInstructionPPC64::EmulateBC,
        "bc BO,BI,TARGET"},
-      {0xfc000002, 0x40000002, &EmulateInstructionPPC64::EmulateBCA,
+      {0xfc000003, 0x40000001, &EmulateInstructionPPC64::EmulateBC,
+       "bcl BO,BI,TARGET"},
+      {0xfc000003, 0x40000002, &EmulateInstructionPPC64::EmulateBC,
        "bca BO,BI,TARGET"},
+      {0xfc000003, 0x40000003, &EmulateInstructionPPC64::EmulateBC,
+       "bcla BO,BI,TARGET"},
       {0xfc0007fe, 0x4c000020, &EmulateInstructionPPC64::EmulateBCLR,
        "bclr BO,BI,BH"},
+      {0xfc0007fe, 0x4c000021, &EmulateInstructionPPC64::EmulateBCLR,
+       "bclrl BO,BI,BH"},
       {0xfc0007fe, 0x4c000420, &EmulateInstructionPPC64::EmulateBCCTR,
        "bcctr BO,BI,BH"},
+      {0xfc0007fe, 0x4c000421, &EmulateInstructionPPC64::EmulateBCCTR,
+       "bcctrl BO,BI,BH"},
       {0xfc0007fe, 0x4c000460, &EmulateInstructionPPC64::EmulateBCTAR,
        "bctar BO,BI,BH"}};
   static const size_t k_num_ppc_opcodes = std::size(g_opcodes);
@@ -193,7 +210,7 @@ bool EmulateInstructionPPC64::EvaluateInstruction(uint32_t evaluate_options) {
   if (!opcode_data)
     return false;
 
-  // LLDB_LOG(log, "PPC64::EvaluateInstruction: {0}", opcode_data->name);
+  // LLDB_LOG(log, "PPC64::EvaluateInstruction: name={0}", opcode_data->name);
   const bool auto_advance_pc =
       evaluate_options & eEmulateInstructionOptionAutoAdvancePC;
 
@@ -251,6 +268,12 @@ bool EmulateInstructionPPC64::EmulateMFSPR(uint32_t opcode) {
       ReadRegisterUnsigned(eRegisterKindLLDB, GetLRRegNum(), 0, &success);
   if (!success)
     return false;
+
+  std::optional<RegisterInfo> rt_info = GetRegisterInfo(eRegisterKindLLDB, rt);
+
+  if (rt_info->byte_size == 4)
+    lr &= 0xFFFFFFFF;
+
   Context context;
   context.type = eContextWriteRegisterRandomBits;
   WriteRegisterUnsigned(context, eRegisterKindLLDB, gpr_r0_ppc64le, lr);
@@ -424,122 +447,314 @@ bool EmulateInstructionPPC64::EmulateADDI(uint32_t opcode) {
   LLDB_LOG(log, "EmulateADDI: success!");
 
   // FIX the next-pc
-  uint64_t pc_value = ReadRegisterUnsigned(eRegisterKindLLDB, GetPCRegNum(), 0, &success);
+  uint64_t pc_value =
+      ReadRegisterUnsigned(eRegisterKindLLDB, GetPCRegNum(), 0, &success);
   uint64_t next_pc = pc_value + 4;
   ctx.type = eContextAdjustPC;
   WriteRegisterUnsigned(ctx, eRegisterKindLLDB, GetPCRegNum(), next_pc);
 
+  return true;
+}
+
+bool EmulateInstructionPPC64::EmulateSTW(uint32_t opcode) {
+  uint32_t rs = Bits32(opcode, 25, 21);
+  uint32_t ra = Bits32(opcode, 20, 16);
+  uint32_t ds = Bits32(opcode, 15, 0);
+  uint32_t u = (Bits32(opcode, 31, 26) == 37) ? 1 : 0; // u = 1 = STWU
+
+  // stwu invalid if RA == 0
+  if (u && ra == 0)
+    return false;
+
+  bool success;
+
+  uint64_t rs_val = ReadRegisterUnsigned(eRegisterKindLLDB, rs, 0, &success);
+  if (!success)
+    return false;
+
+  // Store only low 32 bits (RS)32:63
+  uint32_t store_val = static_cast<uint32_t>(rs_val);
+
+  int64_t ids = llvm::SignExtend64<16>(ds);
+
+  uint64_t ra_val = 0;
+  if (ra != 0) {
+    ra_val = ReadRegisterUnsigned(eRegisterKindLLDB, ra, 0, &success);
+    if (!success)
+      return false;
+  }
+
+  lldb::addr_t addr = ra_val + ids;
+
+  Log *log = GetLog(LLDBLog::Unwind);
+  LLDB_LOG(log, "EmulateSTW: {0:X+8}: stw{1} r{2}, {3}(r{4})", m_addr,
+           u ? "u" : "", rs, ids, ra);
+
+  // Make sure that r0 is really holding LR value (this won't catch unlikely
+  // cases, such as r0 being overwritten after mfspr)
+  uint32_t rs_num = rs;
+  if (rs == gpr_r0_ppc64le) {
+    uint64_t lr =
+        ReadRegisterUnsigned(eRegisterKindLLDB, GetLRRegNum(), 0, &success);
+    if (!success || lr != rs_val)
+      return false;
+    rs_num = GetLRRegNum();
+  }
+
+  // Get register info for unwind modeling
+  std::optional<RegisterInfo> rs_info =
+      GetRegisterInfo(eRegisterKindLLDB, rs_num);
+  std::optional<RegisterInfo> ra_info = GetRegisterInfo(eRegisterKindLLDB, ra);
+
+  if (!rs_info || !ra_info)
+    return false;
+
+  Context ctx;
+  ctx.type = eContextPushRegisterOnStack;
+  ctx.SetRegisterToRegisterPlusOffset(*rs_info, *ra_info, ids);
+
+  WriteMemory(ctx, addr, &store_val, sizeof(store_val));
+
+  // Update form
+  if (u) {
+    Context update_ctx;
+    update_ctx.type = eContextAdjustStackPointer;
+
+    WriteRegisterUnsigned(update_ctx, eRegisterKindLLDB, ra, addr);
+  }
+
+  LLDB_LOG(log, "EmulateSTW: success!");
   return true;
 }
 
 bool EmulateInstructionPPC64::EmulateBC(uint32_t opcode) {
-  // FIXME:32bit M
-  uint32_t M = 0;
-  uint32_t target32 = Bits32(opcode, 15, 2) << 2;
-  uint64_t target = (uint64_t)target32 + ((target32 & 0x8000) ? 0xffffffffffff0000UL : 0);
-  uint32_t BO = Bits32(opcode, 25, 21);
-  bool success;
-  uint64_t ctr_value = ReadRegisterUnsigned(eRegisterKindLLDB, GetCTRRegNum(), 0, &success);
-  if ((~BO) & (1U << 2))
-    ctr_value = ctr_value - 1;
-  bool ctr_ok = (bool)(BO & (1U << 2)) | ((bool)(ctr_value != 0) ^ (bool)(BO & (1U << 1)));
-  uint64_t cr_value = ReadRegisterUnsigned(eRegisterKindLLDB, GetCRRegNum(), 0, &success);
-  uint32_t BI = Bits32(opcode, 20, 16);
-  bool cond_ok = (bool)(BO & (1U << 4)) | (bool)(((cr_value >> (63 - (BI + 32))) & 1U) == ((BO >> 3) & 1U));
-
-  uint64_t pc_value = ReadRegisterUnsigned(eRegisterKindLLDB, GetPCRegNum(), 0, &success);
-  uint64_t next_pc = pc_value + 4;
-  if (ctr_ok & cond_ok)
-    next_pc = pc_value + target;
-
-  Context ctx;
-  ctx.type = eContextAdjustPC;
-  WriteRegisterUnsigned(ctx, eRegisterKindLLDB, GetPCRegNum(), next_pc);
   Log *log = GetLog(LLDBLog::Unwind);
+  LLDB_LOG(log, "EmulateBC: Start!");
+  bool success = false;
+
+  const uint32_t BO = Bits32(opcode, 25, 21);
+  const uint32_t BI = Bits32(opcode, 20, 16);
+  const uint32_t BD = Bits32(opcode, 15, 2);
+  const bool AA = Bits32(opcode, 1, 1);
+  const bool LK = Bits32(opcode, 0, 0);
+
+  const int64_t target_addr = llvm::SignExtend64<16>(BD) << 2;
+  const uint32_t M = m_is_64bit ? 0 : 32;
+
+  // Extract BO field bits
+  bool bo0 = (BO >> 4) & 1; // BO[0]
+  bool bo1 = (BO >> 3) & 1; // BO[1]
+  bool bo2 = (BO >> 2) & 1; // BO[2]
+  bool bo3 = (BO >> 1) & 1; // BO[3]
+
+  uint64_t ctr_value =
+      ReadRegisterUnsigned(eRegisterKindLLDB, GetCTRRegNum(), 0, &success);
+  if (!success)
+    return false;
+
+  if (!bo2) // ¬BO
+    ctr_value = ctr_value - 1;
+
+  bool ctr_ok = bo2 | ((bool)((ctr_value >> M) != 0) ^ bo3);
+
+  const uint32_t cr_value = (uint32_t)ReadRegisterUnsigned(
+      eRegisterKindLLDB, GetCRRegNum(), 0, &success);
+  if (!success)
+    return false;
+
+  bool cond_ok = bo0 | (bool)(((cr_value >> (31 - BI)) & 1U) == bo1);
+
+  const uint64_t pc_value =
+      ReadRegisterUnsigned(eRegisterKindLLDB, GetPCRegNum(), 0, &success);
+  if (!success)
+    return false;
+
+  uint64_t next_pc = pc_value + 4;
+
+  if (ctr_ok && cond_ok) {
+    if (AA)
+      next_pc = target_addr;
+    else
+      next_pc = pc_value + target_addr;
+  }
+  // In 32-bit mode, high-order 32 bits must be zero
+  if (!m_is_64bit)
+    next_pc &= 0xFFFFFFFFULL;
+
+  if (LK) {
+    Context lr_ctx;
+    lr_ctx.type = eContextRegisterStore;
+    WriteRegisterUnsigned(lr_ctx, eRegisterKindLLDB, GetLRRegNum(),
+                          pc_value + 4);
+  }
+
+  if (!bo2) { // ¬BO2
+    Context ctr_ctx;
+    ctr_ctx.type = eContextRegisterStore;
+    WriteRegisterUnsigned(ctr_ctx, eRegisterKindLLDB, GetCTRRegNum(),
+                          ctr_value);
+  }
+
+  Context pc_ctx;
+  pc_ctx.type = eContextAdjustPC;
+  WriteRegisterUnsigned(pc_ctx, eRegisterKindLLDB, GetPCRegNum(), next_pc);
+
+  LLDB_LOG(
+      log,
+      "EmulateBC: BO={0:x} BI={1} AA={2} LK={3} pc_val={4:x} next_pc={5:x}", BO,
+      BI, AA, LK, pc_value, next_pc);
+
   LLDB_LOG(log, "EmulateBC: success!");
   return true;
 }
 
-bool EmulateInstructionPPC64::EmulateBCA(uint32_t opcode) {
-  // FIXME:32bit M
-  uint32_t M = 0;
-  uint32_t target32 = Bits32(opcode, 15, 2) << 2;
-  uint64_t target = (uint64_t)target32 + ((target32 & 0x8000) ? 0xffffffffffff0000UL : 0);
-  uint32_t BO = Bits32(opcode, 25, 21);
-  bool success;
-  uint64_t ctr_value = ReadRegisterUnsigned(eRegisterKindLLDB, GetCTRRegNum(), 0, &success);
-  if ((~BO) & (1U << 2))
-    ctr_value = ctr_value - 1;
-  bool ctr_ok = (bool)(BO & (1U << 2)) | ((bool)(ctr_value != 0) ^ (bool)(BO & (1U << 1)));
-  uint64_t cr_value = ReadRegisterUnsigned(eRegisterKindLLDB, GetCRRegNum(), 0, &success);
-  uint32_t BI = Bits32(opcode, 20, 16);
-  bool cond_ok = (bool)(BO & (1U << 4)) | (bool)(((cr_value >> (63 - (BI + 32))) & 1U) == ((BO >> 3) & 1U));
-
-  uint64_t pc_value = ReadRegisterUnsigned(eRegisterKindLLDB, GetPCRegNum(), 0, &success);
-  uint64_t next_pc = pc_value + 4;
-  if (ctr_ok & cond_ok)
-    next_pc = target;
-
-  Context ctx;
-  ctx.type = eContextAdjustPC;
-  WriteRegisterUnsigned(ctx, eRegisterKindLLDB, GetPCRegNum(), next_pc);
-  Log *log = GetLog(LLDBLog::Unwind);
-  LLDB_LOG(log, "EmulateBCA: success!");
-  return true;
-}
-
 bool EmulateInstructionPPC64::EmulateBCLR(uint32_t opcode) {
-  // FIXME:32bit M
-  uint32_t M = 0;
-  uint32_t BO = Bits32(opcode, 25, 21);
-  bool success;
-  uint64_t ctr_value = ReadRegisterUnsigned(eRegisterKindLLDB, GetCTRRegNum(), 0, &success);
-  if ((~BO) & (1U << 2))
-    ctr_value = ctr_value - 1;
-  bool ctr_ok = (bool)(BO & (1U << 2)) | ((bool)(ctr_value != 0) ^ (bool)(BO & (1U << 1)));
-  uint64_t cr_value = ReadRegisterUnsigned(eRegisterKindLLDB, GetCRRegNum(), 0, &success);
-  uint32_t BI = Bits32(opcode, 20, 16);
-  bool cond_ok = (bool)(BO & (1U << 4)) | (bool)(((cr_value >> (63 - (BI + 32))) & 1U) == ((BO >> 3) & 1U));
+  Log *log = GetLog(LLDBLog::Unwind);
+  LLDB_LOG(log, "EmulateBCLR: Start!");
+  bool success = false;
 
-  uint64_t pc_value = ReadRegisterUnsigned(eRegisterKindLLDB, GetPCRegNum(), 0, &success);
+  const uint32_t BO = Bits32(opcode, 25, 21); // BO field (bits 6-10)
+  const uint32_t BI = Bits32(opcode, 20, 16); // BI field (bits 11-15)
+  const uint32_t BH = Bits32(opcode, 12, 11); // BH field (bits 19-20)
+  const bool LK = Bits32(opcode, 0, 0);       // LK field (bit 31)
+
+  const uint32_t M = m_is_64bit ? 0 : 32;
+
+  // Extract BO field bits
+  bool bo0 = (BO >> 4) & 1; // BO[0]
+  bool bo1 = (BO >> 3) & 1; // BO[1]
+  bool bo2 = (BO >> 2) & 1; // BO[2]
+  bool bo3 = (BO >> 1) & 1; // BO[3]
+
+  uint64_t ctr_value =
+      ReadRegisterUnsigned(eRegisterKindLLDB, GetCTRRegNum(), 0, &success);
+  if (!success)
+    return false;
+
+  if (!bo2) // ¬BO2
+    ctr_value = ctr_value - 1;
+
+  bool ctr_ok = bo2 | ((bool)((ctr_value >> M) != 0) ^ bo3);
+
+  const uint32_t cr_value = (uint32_t)ReadRegisterUnsigned(
+      eRegisterKindLLDB, GetCRRegNum(), 0, &success);
+  if (!success)
+    return false;
+
+  bool cond_ok = bo0 | (bool)(((cr_value >> (31 - BI)) & 1U) == bo1);
+
+  const uint64_t pc_value =
+      ReadRegisterUnsigned(eRegisterKindLLDB, GetPCRegNum(), 0, &success);
+  if (!success)
+    return false;
+
+  const uint64_t lr_value =
+      ReadRegisterUnsigned(eRegisterKindLLDB, GetLRRegNum(), 0, &success);
+  if (!success)
+    return false;
+
   uint64_t next_pc = pc_value + 4;
-  if (ctr_ok & cond_ok) {
-    next_pc = ReadRegisterUnsigned(eRegisterKindLLDB, GetLRRegNum(), 0, &success);
-    next_pc &= ~((1UL << 2) - 1);
+
+  if (ctr_ok && cond_ok) {
+    // Branch target = LR[0:61] || 0b00
+    next_pc = lr_value & 0xFFFFFFFFFFFFFFFCULL; // Clear bits 62-63
+
+    // In 32-bit mode, high-order 32 bits must be zero
+    if (!m_is_64bit)
+      next_pc &= 0xFFFFFFFFULL;
   }
 
-  Context ctx;
-  ctx.type = eContextAdjustPC;
-  WriteRegisterUnsigned(ctx, eRegisterKindLLDB, GetPCRegNum(), next_pc);
-  Log *log = GetLog(LLDBLog::Unwind);
+  if (LK) {
+    Context lr_ctx;
+    lr_ctx.type = eContextRegisterStore;
+    WriteRegisterUnsigned(lr_ctx, eRegisterKindLLDB, GetLRRegNum(),
+                          pc_value + 4);
+  }
+
+  if (!bo2) { // ¬BO2
+    Context ctr_ctx;
+    ctr_ctx.type = eContextRegisterStore;
+    WriteRegisterUnsigned(ctr_ctx, eRegisterKindLLDB, GetCTRRegNum(),
+                          ctr_value);
+  }
+
+  Context pc_ctx;
+  pc_ctx.type = eContextAdjustPC;
+  WriteRegisterUnsigned(pc_ctx, eRegisterKindLLDB, GetPCRegNum(), next_pc);
+
+  LLDB_LOG(log,
+           "EmulateBCLR: BO={0:x} BI={1} BH={2} LK={3} lr_val={4:x} "
+           "pc_val={5:x} next_pc={6:x}",
+           BO, BI, BH, LK, lr_value, pc_value, next_pc);
+
   LLDB_LOG(log, "EmulateBCLR: success!");
   return true;
 }
 
 bool EmulateInstructionPPC64::EmulateBCCTR(uint32_t opcode) {
-  // FIXME:32bit M
-  uint32_t M = 0;
-  uint32_t BO = Bits32(opcode, 25, 21);
-  bool success;
-  uint64_t cr_value = ReadRegisterUnsigned(eRegisterKindLLDB, GetCRRegNum(), 0, &success);
-  uint32_t BI = Bits32(opcode, 20, 16);
-  bool cond_ok = (bool)(BO & (1U << 4)) | (bool)(((cr_value >> (63 - (BI + 32))) & 1U) == ((BO >> 3) & 1U));
-
   Log *log = GetLog(LLDBLog::Unwind);
-  uint64_t pc_value = ReadRegisterUnsigned(eRegisterKindLLDB, GetPCRegNum(), 0, &success);
-  uint64_t next_pc = pc_value + 4;
-  if (cond_ok) {
-    next_pc = ReadRegisterUnsigned(eRegisterKindLLDB, GetCTRRegNum(), 0, &success);
-    next_pc &= ~((1UL << 2) - 1);
-    if (next_pc < 0x4000000) {
-      LLDB_LOGF(log, "EmulateBCCTR: next address %lx out of range, emulate by goto LR!", next_pc);
-      next_pc = ReadRegisterUnsigned(eRegisterKindLLDB, GetLRRegNum(), 0, &success);
-    }
+  LLDB_LOG(log, "EmulateBCCTR: Start!");
+  bool success = false;
+
+  const uint32_t BO = Bits32(opcode, 25, 21); // BO field (bits 6-10)
+  const uint32_t BI = Bits32(opcode, 20, 16); // BI field (bits 11-15)
+  const uint32_t BH = Bits32(opcode, 12, 11); // BH field (bits 19-20)
+  const bool LK = Bits32(opcode, 0, 0);       // LK field (bit 31)
+
+  bool bo0 = (BO >> 4) & 1; // BO[0]
+  bool bo1 = (BO >> 3) & 1; // BO[1]
+  bool bo2 = (BO >> 2) & 1; // BO[2]
+
+  // If BO[2]=0 (decrement and test CTR option), instruction form is invalid
+  if (!bo2) {
+    LLDB_LOG(log, "EmulateBCCTR: Invalid instruction form (BO2=0)");
+    return false;
   }
 
-  Context ctx;
-  ctx.type = eContextAdjustPC;
-  WriteRegisterUnsigned(ctx, eRegisterKindLLDB, GetPCRegNum(), next_pc);
+  const uint32_t cr_value = (uint32_t)ReadRegisterUnsigned(
+      eRegisterKindLLDB, GetCRRegNum(), 0, &success);
+  if (!success)
+    return false;
+
+  bool cond_ok = bo0 | (bool)(((cr_value >> (31 - BI)) & 1U) == bo1);
+
+  const uint64_t pc_value =
+      ReadRegisterUnsigned(eRegisterKindLLDB, GetPCRegNum(), 0, &success);
+  if (!success)
+    return false;
+
+  const uint64_t ctr_value =
+      ReadRegisterUnsigned(eRegisterKindLLDB, GetCTRRegNum(), 0, &success);
+  if (!success)
+    return false;
+
+  uint64_t next_pc = pc_value + 4;
+
+  if (cond_ok) {
+    // Branch target = CTR[0:61] || 0b00
+    next_pc = ctr_value & 0xFFFFFFFFFFFFFFFCULL; // Clear bits 62-63
+
+    // In 32-bit mode, high-order 32 bits must be zero
+    if (!m_is_64bit)
+      next_pc &= 0xFFFFFFFFULL;
+  }
+
+  if (LK) {
+    Context lr_ctx;
+    lr_ctx.type = eContextRegisterStore;
+    WriteRegisterUnsigned(lr_ctx, eRegisterKindLLDB, GetLRRegNum(),
+                          pc_value + 4);
+  }
+
+  Context pc_ctx;
+  pc_ctx.type = eContextAdjustPC;
+  WriteRegisterUnsigned(pc_ctx, eRegisterKindLLDB, GetPCRegNum(), next_pc);
+
+  LLDB_LOG(log,
+           "EmulateBCCTR: BO={0:x} BI={1} BH={2} LK={3} ctr_val={4:x} "
+           "pc_val={5:x} next_pc={6:x}",
+           BO, BI, BH, LK, ctr_value, pc_value, next_pc);
+
   LLDB_LOG(log, "EmulateBCCTR: success!");
   return true;
 }
@@ -552,44 +767,51 @@ bool EmulateInstructionPPC64::EmulateBCTAR(uint32_t opcode) {
 }
 
 bool EmulateInstructionPPC64::EmulateB(uint32_t opcode) {
-  uint32_t target32 = Bits32(opcode, 25, 2) << 2;
-  uint64_t target = (uint64_t)target32 + ((target32 & 0x2000000) ? 0xfffffffffc000000UL : 0);
-
-  bool success;
-  uint64_t pc_value = ReadRegisterUnsigned(eRegisterKindLLDB, GetPCRegNum(), 0, &success);
-  uint64_t next_pc = pc_value + target;
-
-  Context ctx;
-  ctx.type = eContextAdjustPC;
-  WriteRegisterUnsigned(ctx, eRegisterKindLLDB, GetPCRegNum(), next_pc);
   Log *log = GetLog(LLDBLog::Unwind);
+  LLDB_LOG(log, "EmulateB: Start!");
+  bool success = false;
+
+  // Extract instruction fields (I-form)
+  const uint32_t LI = Bits32(opcode, 25, 2); // LI field (bits 6-29)
+  const bool AA = Bits32(opcode, 1, 1);      // AA field (bit 30)
+  const bool LK = Bits32(opcode, 0, 0);      // LK field (bit 31)
+
+  // Sign-extend LI and shift left by 2 (LI || 0b00)
+  const int64_t target_addr = llvm::SignExtend64<26>(LI << 2);
+
+  const uint64_t pc_value =
+      ReadRegisterUnsigned(eRegisterKindLLDB, GetPCRegNum(), 0, &success);
+  if (!success)
+    return false;
+
+  uint64_t next_pc;
+
+  if (AA) {
+    // Absolute addressing: NIA = sign_extend(LI || 0b00)
+    next_pc = static_cast<uint64_t>(target_addr);
+  } else {
+    // Relative addressing: NIA = CIA + sign_extend(LI || 0b00)
+    next_pc = pc_value + target_addr;
+  }
+
+  // In 32-bit mode, high-order 32 bits must be zero
+  if (!m_is_64bit)
+    next_pc &= 0xFFFFFFFFULL;
+
+  if (LK) {
+    Context lr_ctx;
+    lr_ctx.type = eContextRegisterStore;
+    WriteRegisterUnsigned(lr_ctx, eRegisterKindLLDB, GetLRRegNum(),
+                          pc_value + 4);
+  }
+
+  Context pc_ctx;
+  pc_ctx.type = eContextAdjustPC;
+  WriteRegisterUnsigned(pc_ctx, eRegisterKindLLDB, GetPCRegNum(), next_pc);
+
+  LLDB_LOG(log, "EmulateB: LI={0:x} AA={1} LK={2} pc_val={3:x} next_pc={4:x}",
+           LI, AA, LK, pc_value, next_pc);
+
   LLDB_LOG(log, "EmulateB: success!");
-  return true;
-}
-
-bool EmulateInstructionPPC64::EmulateBA(uint32_t opcode) {
-  Log *log = GetLog(LLDBLog::Unwind);
-
-  bool success;
-  uint64_t next_pc = ReadRegisterUnsigned(eRegisterKindLLDB, GetLRRegNum(), 0, &success);
-
-  Context ctx;
-  ctx.type = eContextAdjustPC;
-  WriteRegisterUnsigned(ctx, eRegisterKindLLDB, GetPCRegNum(), next_pc);
-  LLDB_LOG(log, "EmulateBA: emulate by branch to lr!");
-  return true;
-}
-
-bool EmulateInstructionPPC64::EmulateBLA(uint32_t opcode) {
-  Log *log = GetLog(LLDBLog::Unwind);
-
-  bool success;
-  uint64_t pc_value = ReadRegisterUnsigned(eRegisterKindLLDB, GetPCRegNum(), 0, &success);
-  uint64_t next_pc = pc_value + 4;
-
-  Context ctx;
-  ctx.type = eContextAdjustPC;
-  WriteRegisterUnsigned(ctx, eRegisterKindLLDB, GetPCRegNum(), next_pc);
-  LLDB_LOG(log, "EmulateBLA: emulate by branch to lr!");
   return true;
 }

--- a/lldb/source/Plugins/Instruction/PPC64/EmulateInstructionPPC64.cpp
+++ b/lldb/source/Plugins/Instruction/PPC64/EmulateInstructionPPC64.cpp
@@ -54,14 +54,14 @@ EmulateInstructionPPC64::CreateInstance(const ArchSpec &arch,
                                         InstructionType inst_type) {
   if (EmulateInstructionPPC64::SupportsEmulatingInstructionsOfTypeStatic(
           inst_type))
-    if (arch.GetTriple().isPPC64())
+    if (arch.GetTriple().isPPC())
       return new EmulateInstructionPPC64(arch);
 
   return nullptr;
 }
 
 bool EmulateInstructionPPC64::SetTargetTriple(const ArchSpec &arch) {
-  return arch.GetTriple().isPPC64();
+  return arch.GetTriple().isPPC();
 }
 
 static std::optional<RegisterInfo> LLDBTableGetRegisterInfo(uint32_t reg_num, bool m_is_le) {

--- a/lldb/source/Plugins/Instruction/PPC64/EmulateInstructionPPC64.cpp
+++ b/lldb/source/Plugins/Instruction/PPC64/EmulateInstructionPPC64.cpp
@@ -210,7 +210,7 @@ bool EmulateInstructionPPC64::EvaluateInstruction(uint32_t evaluate_options) {
   if (!opcode_data)
     return false;
 
-  // LLDB_LOG(log, "PPC64::EvaluateInstruction: name={0}", opcode_data->name);
+  // LLDB_LOG(log, "PPC64::EvaluateInstruction: {0}", opcode_data->name);
   const bool auto_advance_pc =
       evaluate_options & eEmulateInstructionOptionAutoAdvancePC;
 

--- a/lldb/source/Plugins/Instruction/PPC64/EmulateInstructionPPC64.h
+++ b/lldb/source/Plugins/Instruction/PPC64/EmulateInstructionPPC64.h
@@ -104,16 +104,15 @@ private:
   bool EmulateSTD(uint32_t opcode);
   bool EmulateOR(uint32_t opcode);
   bool EmulateADDI(uint32_t opcode);
+  bool EmulateSTW(uint32_t opcode);
   bool EmulateB(uint32_t opcode);
-  bool EmulateBA(uint32_t opcode);
-  bool EmulateBLA(uint32_t opcode);
   bool EmulateBC(uint32_t opcode);
-  bool EmulateBCA(uint32_t opcode);
   bool EmulateBCLR(uint32_t opcode);
   bool EmulateBCCTR(uint32_t opcode);
   bool EmulateBCTAR(uint32_t opcode);
 
-  bool m_is_little_endian; 
+  bool m_is_little_endian;
+  bool m_is_64bit;
 };
 
 } // namespace lldb_private

--- a/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.cpp
+++ b/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.cpp
@@ -136,6 +136,17 @@ ObjectFile *ObjectFileXCOFF::CreateMemoryInstance(
   return nullptr;
 }
 
+uint16_t ObjectFileXCOFF::GetMagicBytes(DataExtractorSP &extractor_sp,
+                                      lldb::addr_t data_offset,
+                                      lldb::addr_t data_length) {
+  DataExtractorSP magic_extractor_sp =
+      extractor_sp->GetSubsetExtractorSP(data_offset);
+  // Need to set this as XCOFF is only compatible with Big Endian
+  magic_extractor_sp->SetByteOrder(eByteOrderBig);
+  lldb::offset_t offset = 0;
+  return magic_extractor_sp->GetU16(&offset);
+}
+
 size_t ObjectFileXCOFF::GetModuleSpecifications(
     const lldb_private::FileSpec &file, lldb::DataExtractorSP &extractor_sp,
     lldb::offset_t data_offset, lldb::offset_t file_offset,
@@ -147,10 +158,13 @@ size_t ObjectFileXCOFF::GetModuleSpecifications(
 
   if (ObjectFileXCOFF::MagicBytesMatch(extractor_sp, 0,
                                        extractor_sp->GetByteSize())) {
+    const uint16_t magic = GetMagicBytes(extractor_sp, 0, extractor_sp->GetByteSize());
+    const uint32_t cpu_type = (magic == XCOFF::XCOFF64) ? XCOFF::TCPU_PPC64 : XCOFF::TCPU_PPC;
+
     ArchSpec arch_spec =
-        ArchSpec(eArchTypeXCOFF, XCOFF::TCPU_PPC64, LLDB_INVALID_CPUTYPE);
+        ArchSpec(eArchTypeXCOFF, cpu_type, LLDB_INVALID_CPUTYPE);
     ModuleSpec spec(file, arch_spec);
-    spec.GetArchitecture().SetArchitecture(eArchTypeXCOFF, XCOFF::TCPU_PPC64,
+    spec.GetArchitecture().SetArchitecture(eArchTypeXCOFF, cpu_type,
                                            LLDB_INVALID_CPUTYPE,
                                            llvm::Triple::AIX);
     specs.Append(spec);
@@ -454,8 +468,9 @@ void ObjectFileXCOFF::CreateSectionsWithBitness(
 void ObjectFileXCOFF::Dump(Stream *s) {}
 
 ArchSpec ObjectFileXCOFF::GetArchitecture() {
+  const uint32_t cpu_type = m_binary->is64Bit() ? XCOFF::TCPU_PPC64 : XCOFF::TCPU_PPC;
   ArchSpec arch_spec =
-      ArchSpec(eArchTypeXCOFF, XCOFF::TCPU_PPC64, LLDB_INVALID_CPUTYPE);
+      ArchSpec(eArchTypeXCOFF, cpu_type, LLDB_INVALID_CPUTYPE);
   return arch_spec;
 }
 

--- a/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.h
+++ b/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.h
@@ -57,6 +57,8 @@ public:
   static bool MagicBytesMatch(lldb::DataExtractorSP &extractor_sp,
                               lldb::addr_t offset, lldb::addr_t length);
 
+  static uint16_t GetMagicBytes(lldb::DataExtractorSP &extractor_sp, lldb::addr_t offset,
+                              lldb::addr_t length);
   // PluginInterface protocol
   llvm::StringRef GetPluginName() override { return GetPluginNameStatic(); }
 

--- a/lldb/source/Plugins/Process/AIX/NativeProcessAIX.cpp
+++ b/lldb/source/Plugins/Process/AIX/NativeProcessAIX.cpp
@@ -1722,62 +1722,32 @@ void NativeProcessAIX::ThreadWasCreated(NativeThreadAIX &thread) {
 #include "Plugins/Process/Utility/RegisterInfos_ppc64.h"
 #undef DECLARE_REGISTER_INFOS_PPC64_STRUCT
 
-static void GetSPRs(int req, lldb::tid_t tid, void *gpr_t, size_t size) {
-    if( size == sizeof(GPR_PPC64)) {
-      GPR_PPC64 *gpr = static_cast<GPR_PPC64 *>(gpr_t);
-      struct ptxsprs sprs;
+template<typename GPR_T, typename PTSPRS_T>
+static void GetSPRs(int req, lldb::tid_t tid, GPR_T *gpr) {
+    PTSPRS_T sprs;
 
-      ptrace64(req, tid, (long long)&sprs, 0, 0);
+    ptrace64(req, tid, (long long)&sprs, 0, 0);
 
-      gpr->cr = sprs.pt_cr;
-      gpr->msr = sprs.pt_msr;
-      gpr->xer = sprs.pt_xer;
-      gpr->lr = sprs.pt_lr;
-      gpr->ctr = sprs.pt_ctr;
-      gpr->pc = sprs.pt_iar;
-    } 
-    else {
-      GPR_PPC *gpr = static_cast<GPR_PPC *>(gpr_t);
-      struct ptsprs sprs;
-
-      ptrace64(req, tid, (long long)&sprs, 0, 0);
-
-      gpr->cr = sprs.pt_cr;
-      gpr->msr = sprs.pt_msr;
-      gpr->xer = sprs.pt_xer;
-      gpr->lr = sprs.pt_lr;
-      gpr->ctr = sprs.pt_ctr;
-      gpr->pc = sprs.pt_iar;
-    }
+    gpr->cr = sprs.pt_cr;
+    gpr->msr = sprs.pt_msr;
+    gpr->xer = sprs.pt_xer;
+    gpr->lr = sprs.pt_lr;
+    gpr->ctr = sprs.pt_ctr;
+    gpr->pc = sprs.pt_iar;
 }
- 
-static void SetSPRs(int req, lldb::tid_t tid, void *gpr_t, size_t size) {
-    if( size == sizeof(GPR_PPC64)) {
-      GPR_PPC64 *gpr = static_cast<GPR_PPC64 *>(gpr_t);
-      struct ptxsprs sprs;
 
-      sprs.pt_cr = gpr->cr;
-      sprs.pt_msr = gpr->msr;
-      sprs.pt_xer = gpr->xer;
-      sprs.pt_lr = gpr->lr;
-      sprs.pt_ctr = gpr->ctr;
-      sprs.pt_iar = gpr->pc;
+template<typename GPR_T, typename PTSPRS_T>
+static void SetSPRs(int req, lldb::tid_t tid, GPR_T *gpr) {
+    PTSPRS_T sprs;
 
-      ptrace64(req, tid, (long long)&sprs, 0, 0);
-    }
-    else {
-      GPR_PPC *gpr = static_cast<GPR_PPC *>(gpr_t);
-      struct ptsprs sprs;
+    sprs.pt_cr = gpr->cr;
+    sprs.pt_msr = gpr->msr;
+    sprs.pt_xer = gpr->xer;
+    sprs.pt_lr = gpr->lr;
+    sprs.pt_ctr = gpr->ctr;
+    sprs.pt_iar = gpr->pc;
 
-      sprs.pt_cr = gpr->cr;
-      sprs.pt_msr = gpr->msr;
-      sprs.pt_xer = gpr->xer;
-      sprs.pt_lr = gpr->lr;
-      sprs.pt_ctr = gpr->ctr;
-      sprs.pt_iar = gpr->pc;
-
-      ptrace64(req, tid, (long long)&sprs, 0, 0);
-    }
+    ptrace64(req, tid, (long long)&sprs, 0, 0);
 }
 
 // Wrapper for ptrace to catch errors and log calls. Note that ptrace sets
@@ -1816,12 +1786,18 @@ Status NativeProcessAIX::PtraceWrapper(int req, lldb::pid_t pid, void *addr,
   switch (req) {
     case PTT_READ_GPRS:
       ptrace64(req, tid, (long long)data, 0, 0);
-      GetSPRs(PTT_READ_SPRS, tid, data, data_size);
+      if(data_size == sizeof(GPR_PPC))
+        GetSPRs<GPR_PPC,ptsprs>(PTT_READ_SPRS, tid, static_cast<GPR_PPC *>(data));
+      else if(data_size == sizeof(GPR_PPC64))
+        GetSPRs<GPR_PPC64,ptxsprs>(PTT_READ_SPRS, tid, static_cast<GPR_PPC64 *>(data));
       break;
 
     case PTT_WRITE_GPRS:
       ptrace64(req, tid, (long long)data, 0, 0);
-      SetSPRs(PTT_WRITE_SPRS, tid, data, data_size);
+      if(data_size == sizeof(GPR_PPC))
+        SetSPRs<GPR_PPC,ptsprs>(PTT_WRITE_SPRS, tid, static_cast<GPR_PPC *>(data));
+      else if(data_size == sizeof(GPR_PPC64))
+        SetSPRs<GPR_PPC64,ptxsprs>(PTT_WRITE_SPRS, tid, static_cast<GPR_PPC64 *>(data));
       break;
 
     case PTT_READ_FPRS:

--- a/lldb/source/Plugins/Process/AIX/NativeProcessAIX.cpp
+++ b/lldb/source/Plugins/Process/AIX/NativeProcessAIX.cpp
@@ -73,8 +73,6 @@
 #define HWCAP2_MTE (1 << 18)
 #endif
 
-#define DEBUG_PTRACE_MAXBYTES 20
-
 using namespace lldb;
 using namespace lldb_private;
 using namespace lldb_private::process_aix;
@@ -144,6 +142,7 @@ static void MaybeLogLaunchInfo(const ProcessLaunchInfo &info) {
     LLDB_LOG(log, "arg {0}: '{1}'", i, *args);
 }
 
+#define DEBUG_PTRACE_MAXBYTES 20
 static void DisplayBytes(StreamString &s, void *bytes, uint32_t count) {
   uint8_t *ptr = (uint8_t *)bytes;
   const uint32_t loop_count = std::min<uint32_t>(DEBUG_PTRACE_MAXBYTES, count);
@@ -466,6 +465,7 @@ NativeProcessAIX::NativeProcessAIX(::pid_t pid, int terminal_fd,
   // Let our process instance know the thread has stopped.
   SetCurrentThreadID(tids[0]);
   SetState(StateType::eStateStopped, false);
+
 }
 
 llvm::Expected<std::vector<::pid_t>> NativeProcessAIX::Attach(::pid_t pid) {
@@ -1433,27 +1433,31 @@ NativeProcessAIX::GetSoftwareBreakpointTrapOpcode(size_t size_hint) {
 Status NativeProcessAIX::ReadMemory(lldb::addr_t addr, void *buf, size_t size,
                                       size_t &bytes_read) {
   unsigned char *dst = static_cast<unsigned char *>(buf);
-  size_t remainder;
-  long data;
+  constexpr size_t kMaxPtraceBlockSize = IPCDATA;
+  bytes_read = 0;
 
   Log *log = GetLog(POSIXLog::Memory);
   LLDB_LOG(log, "addr = {0}, buf = {1}, size = {2}", addr, buf, size);
 
-  for (bytes_read = 0; bytes_read < size; bytes_read += remainder) {
+  while (bytes_read < size) {
+    size_t remainder = size - bytes_read;
+    remainder = remainder > kMaxPtraceBlockSize ? kMaxPtraceBlockSize : remainder;
+
+    size_t n_long = (remainder + sizeof(int) - 1) / sizeof(int);
+    std::vector<long> data(n_long);
+
     Status error = NativeProcessAIX::PtraceWrapper(
-        PT_READ_BLOCK, GetCurrentThreadID(), (void *)addr, nullptr, sizeof(data), &data);
+        PT_READ_BLOCK, GetCurrentThreadID(), reinterpret_cast<void *>(addr),
+        nullptr, remainder, data.data());
+
     if (error.Fail())
       return error;
 
-    remainder = size - bytes_read;
-    remainder = remainder > k_ptrace_word_size ? k_ptrace_word_size : remainder;
+    memcpy(dst, data.data(), remainder);
 
-    // Copy the data into our buffer
-    memcpy(dst, &data, remainder);
-
-    LLDB_LOG(log, "[{0:x}]:{1:x}", addr, data);
-    addr += k_ptrace_word_size;
-    dst += k_ptrace_word_size;
+    addr += remainder;
+    dst += remainder;
+    bytes_read += remainder;
   }
   return Status();
 }
@@ -1718,32 +1722,62 @@ void NativeProcessAIX::ThreadWasCreated(NativeThreadAIX &thread) {
 #include "Plugins/Process/Utility/RegisterInfos_ppc64.h"
 #undef DECLARE_REGISTER_INFOS_PPC64_STRUCT
 
-static void GetSPRs(int req, lldb::tid_t tid, void *gpr_t) {
-    GPR_PPC64 *gpr = static_cast<GPR_PPC64 *>(gpr_t);
-    struct ptxsprs sprs;
+static void GetSPRs(int req, lldb::tid_t tid, void *gpr_t, size_t size) {
+    if( size == sizeof(GPR_PPC64)) {
+      GPR_PPC64 *gpr = static_cast<GPR_PPC64 *>(gpr_t);
+      struct ptxsprs sprs;
 
-    ptrace64(req, tid, (long long)&sprs, 0, 0);
+      ptrace64(req, tid, (long long)&sprs, 0, 0);
 
-    gpr->cr = sprs.pt_cr;
-    gpr->msr = sprs.pt_msr;
-    gpr->xer = sprs.pt_xer;
-    gpr->lr = sprs.pt_lr;
-    gpr->ctr = sprs.pt_ctr;
-    gpr->pc = sprs.pt_iar;
+      gpr->cr = sprs.pt_cr;
+      gpr->msr = sprs.pt_msr;
+      gpr->xer = sprs.pt_xer;
+      gpr->lr = sprs.pt_lr;
+      gpr->ctr = sprs.pt_ctr;
+      gpr->pc = sprs.pt_iar;
+    } 
+    else {
+      GPR_PPC *gpr = static_cast<GPR_PPC *>(gpr_t);
+      struct ptsprs sprs;
+
+      ptrace64(req, tid, (long long)&sprs, 0, 0);
+
+      gpr->cr = sprs.pt_cr;
+      gpr->msr = sprs.pt_msr;
+      gpr->xer = sprs.pt_xer;
+      gpr->lr = sprs.pt_lr;
+      gpr->ctr = sprs.pt_ctr;
+      gpr->pc = sprs.pt_iar;
+    }
 }
+ 
+static void SetSPRs(int req, lldb::tid_t tid, void *gpr_t, size_t size) {
+    if( size == sizeof(GPR_PPC64)) {
+      GPR_PPC64 *gpr = static_cast<GPR_PPC64 *>(gpr_t);
+      struct ptxsprs sprs;
 
-static void SetSPRs(int req, lldb::tid_t tid, void *gpr_t) {
-    GPR_PPC64 *gpr = static_cast<GPR_PPC64 *>(gpr_t);
-    struct ptxsprs sprs;
+      sprs.pt_cr = gpr->cr;
+      sprs.pt_msr = gpr->msr;
+      sprs.pt_xer = gpr->xer;
+      sprs.pt_lr = gpr->lr;
+      sprs.pt_ctr = gpr->ctr;
+      sprs.pt_iar = gpr->pc;
 
-    sprs.pt_cr = gpr->cr;
-    sprs.pt_msr = gpr->msr;
-    sprs.pt_xer = gpr->xer;
-    sprs.pt_lr = gpr->lr;
-    sprs.pt_ctr = gpr->ctr;
-    sprs.pt_iar = gpr->pc;
+      ptrace64(req, tid, (long long)&sprs, 0, 0);
+    }
+    else {
+      GPR_PPC *gpr = static_cast<GPR_PPC *>(gpr_t);
+      struct ptsprs sprs;
 
-    ptrace64(req, tid, (long long)&sprs, 0, 0);
+      sprs.pt_cr = gpr->cr;
+      sprs.pt_msr = gpr->msr;
+      sprs.pt_xer = gpr->xer;
+      sprs.pt_lr = gpr->lr;
+      sprs.pt_ctr = gpr->ctr;
+      sprs.pt_iar = gpr->pc;
+
+      ptrace64(req, tid, (long long)&sprs, 0, 0);
+    }
 }
 
 // Wrapper for ptrace to catch errors and log calls. Note that ptrace sets
@@ -1782,12 +1816,12 @@ Status NativeProcessAIX::PtraceWrapper(int req, lldb::pid_t pid, void *addr,
   switch (req) {
     case PTT_READ_GPRS:
       ptrace64(req, tid, (long long)data, 0, 0);
-      GetSPRs(PTT_READ_SPRS, tid, data);
+      GetSPRs(PTT_READ_SPRS, tid, data, data_size);
       break;
 
     case PTT_WRITE_GPRS:
       ptrace64(req, tid, (long long)data, 0, 0);
-      SetSPRs(PTT_WRITE_SPRS, tid, data);
+      SetSPRs(PTT_WRITE_SPRS, tid, data, data_size);
       break;
 
     case PTT_READ_FPRS:

--- a/lldb/source/Plugins/Process/AIX/NativeProcessAIX.cpp
+++ b/lldb/source/Plugins/Process/AIX/NativeProcessAIX.cpp
@@ -73,6 +73,8 @@
 #define HWCAP2_MTE (1 << 18)
 #endif
 
+#define DEBUG_PTRACE_MAXBYTES 20
+
 using namespace lldb;
 using namespace lldb_private;
 using namespace lldb_private::process_aix;
@@ -142,7 +144,6 @@ static void MaybeLogLaunchInfo(const ProcessLaunchInfo &info) {
     LLDB_LOG(log, "arg {0}: '{1}'", i, *args);
 }
 
-#define DEBUG_PTRACE_MAXBYTES 20
 static void DisplayBytes(StreamString &s, void *bytes, uint32_t count) {
   uint8_t *ptr = (uint8_t *)bytes;
   const uint32_t loop_count = std::min<uint32_t>(DEBUG_PTRACE_MAXBYTES, count);
@@ -465,7 +466,6 @@ NativeProcessAIX::NativeProcessAIX(::pid_t pid, int terminal_fd,
   // Let our process instance know the thread has stopped.
   SetCurrentThreadID(tids[0]);
   SetState(StateType::eStateStopped, false);
-
 }
 
 llvm::Expected<std::vector<::pid_t>> NativeProcessAIX::Attach(::pid_t pid) {

--- a/lldb/source/Plugins/Process/AIX/NativeRegisterContextAIX_ppc64.cpp
+++ b/lldb/source/Plugins/Process/AIX/NativeRegisterContextAIX_ppc64.cpp
@@ -115,6 +115,7 @@ std::unique_ptr<NativeRegisterContextAIX>
 NativeRegisterContextAIX::CreateHostNativeRegisterContextAIX(
     const ArchSpec &target_arch, NativeThreadAIX &native_thread) {
   switch (target_arch.GetMachine()) {
+  case llvm::Triple::ppc:
   case llvm::Triple::ppc64:
     return std::make_unique<NativeRegisterContextAIX_ppc64>(target_arch,
                                                                  native_thread);
@@ -128,11 +129,16 @@ NativeRegisterContextAIX_ppc64::NativeRegisterContextAIX_ppc64(
     : NativeRegisterContextRegisterInfo(
           native_thread, new RegisterInfoPOSIX_ppc64(target_arch)),
       NativeRegisterContextAIX(native_thread) {
-  if (target_arch.GetMachine() != llvm::Triple::ppc64) {
-    llvm_unreachable("Unhandled target architecture.");
+  switch (target_arch.GetMachine()) {
+      case llvm::Triple::ppc:
+          m_gpr = &m_gpr_storage.gpr32;
+          break;
+      case llvm::Triple::ppc64:
+          m_gpr = &m_gpr_storage.gpr64;
+          break;
+      default:
+          llvm_unreachable("Unhandled target architecture.");
   }
-
-  ::memset(&m_gpr_ppc64, 0, sizeof(m_gpr_ppc64));
   ::memset(&m_fpr_ppc64, 0, sizeof(m_fpr_ppc64));
   ::memset(&m_vmx_ppc64, 0, sizeof(m_vmx_ppc64));
   ::memset(&m_vsx_ppc64, 0, sizeof(m_vsx_ppc64));
@@ -230,7 +236,7 @@ Status NativeRegisterContextAIX_ppc64::ReadRegister(
     if (error.Fail())
       return error;
 
-    uint8_t *src = (uint8_t *) &m_gpr_ppc64 + reg_info->byte_offset;
+    const uint8_t *src = reinterpret_cast<const uint8_t *>(GetGPRBuffer()) + reg_info->byte_offset;
     reg_value.SetFromMemoryData(*reg_info, src, reg_info->byte_size,
                                 eByteOrderBig, error);
   } else {
@@ -258,7 +264,7 @@ Status NativeRegisterContextAIX_ppc64::WriteRegister(
     if (error.Fail())
       return error;
 
-    uint8_t *dst = (uint8_t *)&m_gpr_ppc64 + reg_info->byte_offset;
+     uint8_t *dst = reinterpret_cast< uint8_t *>(GetGPRBuffer()) + reg_info->byte_offset;
     ::memcpy(dst, reg_value.GetBytes(), reg_value.GetByteSize());
 
     error = WriteGPR();
@@ -370,7 +376,7 @@ Status NativeRegisterContextAIX_ppc64::ReadAllRegisterValues(
     return error;
 
   uint8_t *dst = data_sp->GetBytes();
-  ::memcpy(dst, &m_gpr_ppc64, GetGPRSize());
+  ::memcpy(dst, GetGPRBuffer(), GetGPRSize());
   dst += GetGPRSize();
   ::memcpy(dst, &m_fpr_ppc64, GetFPRSize());
   dst += GetFPRSize();
@@ -409,7 +415,7 @@ Status NativeRegisterContextAIX_ppc64::WriteAllRegisterValues(
     return error;
   }
 
-  ::memcpy(&m_gpr_ppc64, src, GetGPRSize());
+  ::memcpy(GetGPRBuffer(), src, GetGPRSize());
   error = WriteGPR();
 
   if (error.Fail())

--- a/lldb/source/Plugins/Process/AIX/NativeRegisterContextAIX_ppc64.cpp
+++ b/lldb/source/Plugins/Process/AIX/NativeRegisterContextAIX_ppc64.cpp
@@ -264,7 +264,7 @@ Status NativeRegisterContextAIX_ppc64::WriteRegister(
     if (error.Fail())
       return error;
 
-     uint8_t *dst = reinterpret_cast< uint8_t *>(GetGPRBuffer()) + reg_info->byte_offset;
+    uint8_t *dst = reinterpret_cast< uint8_t *>(GetGPRBuffer()) + reg_info->byte_offset;
     ::memcpy(dst, reg_value.GetBytes(), reg_value.GetByteSize());
 
     error = WriteGPR();

--- a/lldb/source/Plugins/Process/AIX/NativeRegisterContextAIX_ppc64.h
+++ b/lldb/source/Plugins/Process/AIX/NativeRegisterContextAIX_ppc64.h
@@ -29,7 +29,7 @@ class NativeProcessAIX;
 class NativeRegisterContextAIX_ppc64 : public NativeRegisterContextAIX {
 public:
   NativeRegisterContextAIX_ppc64(const ArchSpec &target_arch,
-                                     NativeThreadProtocol &native_thread);
+                                 NativeThreadProtocol &native_thread);
 
   uint32_t GetRegisterSetCount() const override;
 
@@ -80,14 +80,22 @@ protected:
 
   Status WriteVSX();
 
-  void *GetGPRBuffer() override { return &m_gpr_ppc64; }
+  void *GetGPRBuffer() override { return m_gpr; }
 
   void *GetFPRBuffer() override { return &m_fpr_ppc64; }
 
   size_t GetFPRSize() override { return sizeof(m_fpr_ppc64); }
 
 private:
-  GPR_PPC64 m_gpr_ppc64; // 64-bit general purpose registers.
+  union GPRStorage {
+    GPR_PPC gpr32;   // 32-bit general purpose registers.
+    GPR_PPC64 gpr64; // 64-bit general purpose registers.
+  };
+
+  GPRStorage m_gpr_storage;
+
+  void *m_gpr = nullptr;
+
   FPR_PPC64 m_fpr_ppc64; // floating-point registers including extended register.
   VMX_PPC64 m_vmx_ppc64; // VMX registers.
   VSX_PPC64 m_vsx_ppc64; // Last lower bytes from first VSX registers.
@@ -133,6 +141,6 @@ private:
 } // namespace process_aix
 } // namespace lldb_private
 
-#endif // #ifndef LLDB_SOURCE_PLUGINS_PROCESS_AIX_NATIVEREGISTECONTXTAIX_PPC64_H 
+#endif // #ifndef LLDB_SOURCE_PLUGINS_PROCESS_AIX_NATIVEREGISTECONTXTAIX_PPC64_H
 
 #endif // defined(__powerpc64__)

--- a/lldb/source/Plugins/Process/Utility/InferiorCallPOSIX.cpp
+++ b/lldb/source/Plugins/Process/Utility/InferiorCallPOSIX.cpp
@@ -51,7 +51,7 @@ bool lldb_private::InferiorCallMmap(Process *process, addr_t &allocated_addr,
       ConstString("mmap"), eFunctionNameTypeFull, function_options, sc_list);
 #else
   process->GetTarget().GetImages().FindFunctions(
-      ConstString("mmap64"), eFunctionNameTypeFull, function_options, sc_list);
+      ConstString("mmap"), eFunctionNameTypeFull, function_options, sc_list);
   SymbolContextList toc_list;
   process->GetTarget().GetImages().FindSymbolsWithNameAndType(
       ConstString("TOC"), lldb::eSymbolTypeAny, toc_list);

--- a/lldb/source/Plugins/Process/Utility/RegisterInfoPOSIX_ppc64.cpp
+++ b/lldb/source/Plugins/Process/Utility/RegisterInfoPOSIX_ppc64.cpp
@@ -23,6 +23,8 @@
 static const lldb_private::RegisterInfo *
 GetRegisterInfoPtr(const lldb_private::ArchSpec &target_arch) {
   switch (target_arch.GetMachine()) {
+  case llvm::Triple::ppc:
+    return g_register_infos_ppc;
   case llvm::Triple::ppc64:
     return g_register_infos_ppc64;
   default:
@@ -34,6 +36,9 @@ GetRegisterInfoPtr(const lldb_private::ArchSpec &target_arch) {
 static uint32_t
 GetRegisterInfoCount(const lldb_private::ArchSpec &target_arch) {
   switch (target_arch.GetMachine()) {
+  case llvm::Triple::ppc:
+    return static_cast<uint32_t>(sizeof(g_register_infos_ppc) /
+                                 sizeof(g_register_infos_ppc[0]));
   case llvm::Triple::ppc64:
     return static_cast<uint32_t>(sizeof(g_register_infos_ppc64) /
                                  sizeof(g_register_infos_ppc64[0]));
@@ -47,9 +52,21 @@ RegisterInfoPOSIX_ppc64::RegisterInfoPOSIX_ppc64(
     const lldb_private::ArchSpec &target_arch)
     : lldb_private::RegisterInfoInterface(target_arch),
       m_register_info_p(GetRegisterInfoPtr(target_arch)),
-      m_register_info_count(GetRegisterInfoCount(target_arch)) {}
+      m_register_info_count(GetRegisterInfoCount(target_arch)), m_gpr_size(0) {
+  switch (target_arch.GetMachine()) {
+  case llvm::Triple::ppc:
+    m_gpr_size = sizeof(GPR_PPC);
+    break;
+  case llvm::Triple::ppc64:
+    m_gpr_size = sizeof(GPR_PPC64);
+    break;
+  default:
+    assert(false && "Unhandled target architecture.");
+    break;
+  }
+}
 
-size_t RegisterInfoPOSIX_ppc64::GetGPRSize() const { return sizeof(GPR_PPC64); }
+size_t RegisterInfoPOSIX_ppc64::GetGPRSize() const { return m_gpr_size; }
 
 const lldb_private::RegisterInfo *
 RegisterInfoPOSIX_ppc64::GetRegisterInfo() const {

--- a/lldb/source/Plugins/Process/Utility/RegisterInfoPOSIX_ppc64.h
+++ b/lldb/source/Plugins/Process/Utility/RegisterInfoPOSIX_ppc64.h
@@ -26,6 +26,7 @@ public:
 private:
   const lldb_private::RegisterInfo *m_register_info_p;
   uint32_t m_register_info_count;
+  size_t m_gpr_size;
 };
 
 #endif // LLDB_SOURCE_PLUGINS_PROCESS_UTILITY_REGISTERINFOPOSIX_PPC64_H

--- a/lldb/source/Plugins/Process/Utility/RegisterInfoPOSIX_ppc64le.cpp
+++ b/lldb/source/Plugins/Process/Utility/RegisterInfoPOSIX_ppc64le.cpp
@@ -23,8 +23,6 @@
 static const lldb_private::RegisterInfo *
 GetRegisterInfoPtr(const lldb_private::ArchSpec &target_arch) {
   switch (target_arch.GetMachine()) {
-  //HH
-  case llvm::Triple::ppc64:
   case llvm::Triple::ppc64le:
     return g_register_infos_ppc64le;
   default:
@@ -36,8 +34,6 @@ GetRegisterInfoPtr(const lldb_private::ArchSpec &target_arch) {
 static uint32_t
 GetRegisterInfoCount(const lldb_private::ArchSpec &target_arch) {
   switch (target_arch.GetMachine()) {
-  //HitchHike
-  case llvm::Triple::ppc64:
   case llvm::Triple::ppc64le:
     return static_cast<uint32_t>(sizeof(g_register_infos_ppc64le) /
                                  sizeof(g_register_infos_ppc64le[0]));

--- a/lldb/source/Plugins/Process/Utility/RegisterInfos_ppc64.h
+++ b/lldb/source/Plugins/Process/Utility/RegisterInfos_ppc64.h
@@ -340,6 +340,48 @@ typedef struct _GPR_PPC64 {
   uint64_t pad[3];
 } GPR_PPC64;
 
+typedef struct _GPR_PPC {
+  uint32_t r0;
+  uint32_t r1;
+  uint32_t r2;
+  uint32_t r3;
+  uint32_t r4;
+  uint32_t r5;
+  uint32_t r6;
+  uint32_t r7;
+  uint32_t r8;
+  uint32_t r9;
+  uint32_t r10;
+  uint32_t r11;
+  uint32_t r12;
+  uint32_t r13;
+  uint32_t r14;
+  uint32_t r15;
+  uint32_t r16;
+  uint32_t r17;
+  uint32_t r18;
+  uint32_t r19;
+  uint32_t r20;
+  uint32_t r21;
+  uint32_t r22;
+  uint32_t r23;
+  uint32_t r24;
+  uint32_t r25;
+  uint32_t r26;
+  uint32_t r27;
+  uint32_t r28;
+  uint32_t r29;
+  uint32_t r30;
+  uint32_t r31;
+  uint32_t cr;
+  uint32_t msr;
+  uint32_t xer;
+  uint32_t lr;
+  uint32_t ctr;
+  uint32_t pc;
+  uint32_t pad[3];
+} GPR_PPC;
+
 typedef struct _FPR_PPC64 {
   uint64_t f0;
   uint64_t f1;
@@ -486,6 +528,17 @@ static lldb_private::RegisterInfo g_register_infos_ppc64[] = {PPC64_REGS};
 static_assert((sizeof(g_register_infos_ppc64) /
                sizeof(g_register_infos_ppc64[0])) == k_num_registers_ppc64,
               "g_register_infos_powerpc64 has wrong number of register infos");
+
+static lldb_private::RegisterInfo g_register_infos_ppc[] = {
+#define GPR_PPC64 GPR_PPC
+    PPC64_REGS
+#undef GPR_PPC64
+};
+
+static_assert((sizeof(g_register_infos_ppc) /
+               sizeof(g_register_infos_ppc[0])) ==
+                  k_num_registers_ppc64,
+              "g_register_infos_powerpc has wrong number of register infos");
 
 #undef DEFINE_FPR_PPC64
 #undef DEFINE_GPR_PPC64

--- a/lldb/source/Target/RegisterContextUnwind.cpp
+++ b/lldb/source/Target/RegisterContextUnwind.cpp
@@ -1570,7 +1570,7 @@ RegisterContextUnwind::SavedLocationForRegister(
       regloc.location.register_number = regnum.GetAsKind(eRegisterKindLLDB);
 #ifdef _AIX
       if (UGLY_HACK_NULL_TOPFRAME && regloc.location.register_number == 0x20) {
-        regloc.location.register_number = 0x24;
+        regloc.location.register_number = 0x23;
       }
 #endif
       m_registers[regnum.GetAsKind(eRegisterKindLLDB)] = regloc;

--- a/lldb/source/Target/RegisterContextUnwind.cpp
+++ b/lldb/source/Target/RegisterContextUnwind.cpp
@@ -1569,6 +1569,7 @@ RegisterContextUnwind::SavedLocationForRegister(
           UnwindLLDB::ConcreteRegisterLocation::eRegisterInLiveRegisterContext;
       regloc.location.register_number = regnum.GetAsKind(eRegisterKindLLDB);
 #ifdef _AIX
+      // FIXME: hack - assign the LR register number
       if (UGLY_HACK_NULL_TOPFRAME && regloc.location.register_number == 0x20) {
         regloc.location.register_number = 0x23;
       }

--- a/lldb/source/Utility/ArchSpec.cpp
+++ b/lldb/source/Utility/ArchSpec.cpp
@@ -443,7 +443,7 @@ static const ArchDefinition g_coff_arch_def = {
 
 // clang-format off
 static const ArchDefinitionEntry g_xcoff_arch_entries[] = {
-    {ArchSpec::eCore_ppc_generic,   llvm::XCOFF::TCPU_COM},
+    {ArchSpec::eCore_ppc_generic,   llvm::XCOFF::TCPU_PPC},
     {ArchSpec::eCore_ppc64_generic, llvm::XCOFF::TCPU_PPC64}
 };
 // clang-format on


### PR DESCRIPTION
Added support for debugging 32-bit binaries using LLDB. 
This change also refactors and extends portions of the common debugging infrastructure shared between 32-bit and 64-bit paths. As part of this update, memory reads have been optimized to fetch 1024 bytes per ptrace call, reducing the number of system calls. 
Additionally, enhancements were made to the instruction emulation component to improve code reuse and maintain a unified implementation for both 32-bit and 64-bit architectures.
 
```
# lldb iss_51_32
(lldb) target create "iss_51_32"
Current executable set to '/LLDB/hemang/testcase/iss_51_32' (powerpc).
(lldb) b main
Breakpoint 1: where = iss_51_32`main + 32 at iss_51.c:24, address = 0x10000760
(lldb) r
Process 12583214 launched: '/LLDB/hemang/testcase/iss_51_32' (powerpc)
Process 12583214 stopped
* thread #1, name = 'iss_51_32', stop reason = breakpoint 1.1
    frame #0: 0x10000760 iss_51_32`main at iss_51.c:24
   21       int choice;
   22  
   23       // Modify and print union data
-> 24       printf("Enter 1 for int, 2 for float, 3 for string: ");
   25       scanf("%d", &choice);
   26       modifyUnion(&data, choice);
   27       printUnion(&data);
(lldb) re r
General Purpose Registers:
        r0 = 0x100002d4  iss_51_32`__start + 108
        r1 = 0x2ff22850
        r2 = 0x20000f3c  TOC
        r3 = 0x00000000  
        r4 = 0x2ff22920
        r5 = 0x2ff22928
        r6 = 0x0000f032
        r7 = 0x2ff22ff8
        r8 = 0x00000000  
        r9 = 0x50fce000
       r10 = 0x00000000  
       r11 = 0x00001030
       r12 = 0x22628480
       r13 = 0xdeadbeef
       r14 = 0x00000001  
       r15 = 0x2ff22920
       r16 = 0x2ff22928
       r17 = 0xdeadbeef
       r18 = 0xdeadbeef
       r19 = 0xf0aa0b00  __mod_init
       r20 = 0xdeadbeef
       r21 = 0xdeadbeef
       r22 = 0xdeadbeef
       r23 = 0xdeadbeef
       r24 = 0xdeadbeef
       r25 = 0xdeadbeef
       r26 = 0x4c54e289
       r27 = 0x00000008  
       r28 = 0xf0325000  libpthreads.a..data + 0
       r29 = 0xd0616000
       r30 = 0x00000007  
       r31 = 0x2ff22850
        cr = 0x28628284
       msr = 0x0000d032
       xer = 0x00000000  
        lr = 0x100002d4  iss_51_32`__start + 108
       ctr = 0x00000000  
        pc = 0x10000760  iss_51_32`main + 32 at iss_51.c:24

```