### PR TITLE
Coredump issues with watchpoint rerun and 32-bit coredump loading

### DIFF
--- a/lldb/source/Breakpoint/Watchpoint.cpp
+++ b/lldb/source/Breakpoint/Watchpoint.cpp
@@ -410,9 +410,11 @@ bool Watchpoint::IsDisabledDuringEphemeralMode() {
 
 void Watchpoint::SetEnabled(bool enabled, bool notify) {
   if (!m_new_value_sp) {
-    ExecutionContext exe_ctx;
-    m_target.GetProcessSP()->CalculateExecutionContext(exe_ctx);
-    CaptureWatchedValue(exe_ctx);
+    if (ProcessSP process_sp = m_target.GetProcessSP()) {  
+        ExecutionContext exe_ctx;
+        process_sp->CalculateExecutionContext(exe_ctx);
+        CaptureWatchedValue(exe_ctx);
+    }
   }
   if (!enabled) {
     if (m_is_ephemeral)

--- a/lldb/source/Breakpoint/Watchpoint.cpp
+++ b/lldb/source/Breakpoint/Watchpoint.cpp
@@ -409,6 +409,11 @@ bool Watchpoint::IsDisabledDuringEphemeralMode() {
 }
 
 void Watchpoint::SetEnabled(bool enabled, bool notify) {
+  if (!m_new_value_sp) {
+    ExecutionContext exe_ctx;
+    m_target.GetProcessSP()->CalculateExecutionContext(exe_ctx);
+    CaptureWatchedValue(exe_ctx);
+  }
   if (!enabled) {
     if (m_is_ephemeral)
       ++m_disabled_count;

--- a/lldb/source/Plugins/Process/aix-core/ThreadAIXCore.cpp
+++ b/lldb/source/Plugins/Process/aix-core/ThreadAIXCore.cpp
@@ -19,6 +19,7 @@
 #include "Plugins/Process/Utility/RegisterContextPOSIX_powerpc.h"
 #include "Plugins/Process/Utility/RegisterContextPOSIX_ppc64le.h"
 #include "Plugins/Process/Utility/RegisterInfoPOSIX_ppc64le.h"
+#include "Plugins/Process/Utility/RegisterInfoPOSIX_ppc64.h"
 #include "Plugins/Process/elf-core/RegisterContextPOSIXCore_powerpc.h"
 #include "RegisterContextCoreAIX_ppc64.h"
 
@@ -79,8 +80,9 @@ ThreadAIXCore::CreateRegisterContextForFrame(StackFrame *frame) {
     RegisterInfoInterface *reg_interface = nullptr;
 
     switch (arch.GetMachine()) {
+        case llvm::Triple::ppc:
         case llvm::Triple::ppc64:
-            reg_interface = new RegisterInfoPOSIX_ppc64le(arch);
+            reg_interface = new RegisterInfoPOSIX_ppc64(arch);
             m_thread_reg_ctx_sp = std::make_shared<RegisterContextCoreAIX_ppc64>(
                     *this, reg_interface, m_gpregset_data);
             break;


### PR DESCRIPTION
Fixes

-  #155 

This PR fixes two separate coredump issues:

1. Coredump with all platforms (Mac, Linux, AIX etc) with watchpoint rerun on same variable
2. Coredump with loading 32-bit coredump due to internal design changes. 