### PR TITLE
Fix coredump on quit

### DIFF
--- a/lldb/source/Plugins/DynamicLoader/AIX-DYLD/DynamicLoaderAIXDYLD.cpp
+++ b/lldb/source/Plugins/DynamicLoader/AIX-DYLD/DynamicLoaderAIXDYLD.cpp
@@ -45,7 +45,9 @@ void DynamicLoaderAIXDYLD::Initialize() {
                                 GetPluginDescriptionStatic(), CreateInstance);
 }
 
-void DynamicLoaderAIXDYLD::Terminate() {}
+void DynamicLoaderAIXDYLD::Terminate() {
+  PluginManager::UnregisterPlugin(CreateInstance);
+}
 
 llvm::StringRef DynamicLoaderAIXDYLD::GetPluginDescriptionStatic() {
   return "Dynamic loader plug-in that watches for shared library "


### PR DESCRIPTION
Fixed core dump when quitting application

without fix
```
(lldb) q
Quitting LLDB will kill one or more processes. Do you really want to proceed: [Y/n] y
Use `image lookup -va 0x0000000110995f50` to find out which callback was not removed
Assertion failed: m_instances.empty() && "forgot to unregister plugin?", file  /LLDB/hemang/lldb-for-aix/lldb/source/Core/PluginManager.cpp, line 503, PluginInstances<PluginInstance<lldb_private::DynamicLoader *(*)(lldb_private::Process *, bool)>>::~PluginInstances() [Instance = PluginInstance<lldb_private::DynamicLoader *(*)(lldb_private::Process *, bool)>]()
PLEASE submit a bug report to https://github.com/llvm/llvm-project/issues/ and include the crash backtrace.
LLDB diagnostics will be written to /tmp/diagnostics-0d6d27
Please include the directory content when filing a bug report
IOT/Abort trap (core dumped)
```

with fix
```
(lldb) q
Quitting LLDB will kill one or more processes. Do you really want to proceed: [Y/n] y

# 
```