### PR TITLE
Fix for stl, vector and static variable access for 32-bit

### DIFF
--- a/lldb/source/Plugins/Instruction/PPC64/EmulateInstructionPPC64.cpp
+++ b/lldb/source/Plugins/Instruction/PPC64/EmulateInstructionPPC64.cpp
@@ -538,7 +538,7 @@ bool EmulateInstructionPPC64::EmulateBC(uint32_t opcode) {
   const bool AA = Bits32(opcode, 1, 1);
   const bool LK = Bits32(opcode, 0, 0);
 
-  const int64_t target_addr = llvm::SignExtend64<16>(BD) << 2;
+  const int64_t target_addr = llvm::SignExtend64<16>(BD << 2);
   const uint32_t M = m_is_64bit ? 0 : 32;
 
   // Extract BO field bits

--- a/lldb/source/Plugins/Language/CPlusPlus/GenericList.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/GenericList.cpp
@@ -464,7 +464,11 @@ lldb::ChildCacheState LibCxxListFrontEnd::Update() {
   ValueObjectSP backend_addr(m_backend.AddressOf(err));
   if (err.Fail() || !backend_addr)
     return lldb::ChildCacheState::eRefetch;
+#ifdef _AIX
+  m_node_address = m_backend.GetAddressOf(false).address;
+#else
   m_node_address = backend_addr->GetValueAsUnsigned(0);
+#endif
   if (!m_node_address || m_node_address == LLDB_INVALID_ADDRESS)
     return lldb::ChildCacheState::eRefetch;
   ValueObjectSP impl_sp(m_backend.GetChildMemberWithName("__end_"));

--- a/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.cpp
+++ b/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.cpp
@@ -86,6 +86,11 @@ ObjectFile *ObjectFileXCOFF::CreateInstance(const lldb::ModuleSP &module_sp,
     data_offset = 0;
     extractor_sp = std::make_shared<lldb_private::DataExtractor>(data_sp);
   }
+  const uint16_t magic = GetMagicBytes(extractor_sp, 0, length);
+  Log *log = GetLog(LLDBLog::Object);
+  extractor_sp->SetAddressByteSize((magic == XCOFF::XCOFF64) ? 8 : 4);
+  extractor_sp->SetByteOrder(lldb::eByteOrderBig);
+
   auto objfile_up = std::make_unique<ObjectFileXCOFF>(
       module_sp, extractor_sp, data_offset, file, file_offset, length);
   if (!objfile_up)

--- a/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.cpp
+++ b/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.cpp
@@ -87,7 +87,6 @@ ObjectFile *ObjectFileXCOFF::CreateInstance(const lldb::ModuleSP &module_sp,
     extractor_sp = std::make_shared<lldb_private::DataExtractor>(data_sp);
   }
   const uint16_t magic = GetMagicBytes(extractor_sp, 0, length);
-  Log *log = GetLog(LLDBLog::Object);
   extractor_sp->SetAddressByteSize((magic == XCOFF::XCOFF64) ? 8 : 4);
   extractor_sp->SetByteOrder(lldb::eByteOrderBig);
 

--- a/lldb/source/ValueObject/ValueObject.cpp
+++ b/lldb/source/ValueObject/ValueObject.cpp
@@ -3551,12 +3551,19 @@ lldb::ValueObjectSP ValueObject::CreateValueObjectFromAddress(
     if (!do_deref)
       pointer_type = type;
     if (pointer_type) {
+#ifdef _AIX
+      lldb::ValueObjectSP ptr_result_valobj_sp(ValueObjectConstResult::Create(
+          exe_ctx.GetBestExecutionContextScope(), pointer_type,
+          ConstString(name), address, eAddressTypeHost,
+          exe_ctx.GetAddressByteSize()));
+#else
       lldb::DataBufferSP buffer(
           new lldb_private::DataBufferHeap(&address, sizeof(lldb::addr_t)));
       lldb::ValueObjectSP ptr_result_valobj_sp(ValueObjectConstResult::Create(
           exe_ctx.GetBestExecutionContextScope(), pointer_type,
           ConstString(name), buffer, exe_ctx.GetByteOrder(),
           exe_ctx.GetAddressByteSize()));
+#endif
       if (ptr_result_valobj_sp) {
         if (do_deref)
           ptr_result_valobj_sp->GetValue().SetValueType(


### PR DESCRIPTION
Fix for stl/vector and static/global variable access issue.
There is emulator changes included with this PR, its not related to this fix but as it was typo i have made with this PR only.

Testcase:
```
Cpp file:-
========
#include <iostream>
#include <vector>
int main() {
    std::vector<int> vec = {1, 2, 3, 4, 5};
    auto it = vec.begin();
    while (it != vec.end()) {
        std::cout << *it << " ";
        ++it;
    }
    return 0;
}
```
Without Fix:
```
(lldb) p vec
(std::__1::vector<int, std::__1::allocator<int> >) size=0 {} 
```
With Fix:
```
(lldb) p vec 
(std::__1::vector<int, std::__1::allocator<int> >) size=5 {
  [0] = 1
  [1] = 2
  [2] = 3
  [3] = 4
  [4] = 5
}
```

Testcase:
```
#include <iostream>

static int staticVariable = 42;

void printStaticVariable() {
    std::cout << "Static variable value: " << staticVariable << std::endl;
}

int main() {
    printStaticVariable();
    return 0;
}
```
Without Fix:
```
(lldb) p staticVariable

error: Couldn't materialize: couldn't get the value of variable staticVariable: Unhandled opcode DW_OP_unknown_0 in DWARFExpression
error: errored out in DoExecute, couldn't PrepareToExecuteJITExpression

```
With Fix:
```
(lldb) p staticVariable 
(int) 42
```