### PR TITLE
Fix for value size in watch expression

### DIFF
--- a/lldb/source/Commands/CommandObjectWatchpoint.cpp
+++ b/lldb/source/Commands/CommandObjectWatchpoint.cpp
@@ -1051,8 +1051,26 @@ protected:
 
     if (m_option_watchpoint.watch_size.GetCurrentValue() != 0)
       size = m_option_watchpoint.watch_size.GetCurrentValue();
-    else
+    else {
+#ifndef _AIX
       size = target.GetArchitecture().GetAddressByteSize();
+#else
+      CompilerType expr_compiler_type = valobj_sp->GetCompilerType();
+      CompilerType pointee_type = expr_compiler_type.GetPointeeType();
+      if (pointee_type.IsValid()) {
+          if (auto pointee_size = pointee_type.GetByteSize(nullptr))
+              size = *pointee_size;
+          else
+              size = target.GetArchitecture().GetAddressByteSize();
+      } else {
+          size = target.GetArchitecture().GetAddressByteSize();
+          result.AppendWarning(
+              "Cannot infer watchpoint size from expression. "
+              "Defaulting to pointer size. \n"
+              "Use -s option to specify size explicitly.");
+      }
+#endif
+    }
 
     // Now it's time to create the watchpoint.
     uint32_t watch_type;
@@ -1080,15 +1098,21 @@ protected:
 
     std::optional<uint64_t> valobj_size =
         llvm::expectedToOptional(valobj_sp->GetByteSize());
+
     // Set the type as a uint8_t array if the size being watched is
     // larger than the ValueObject's size (which is probably the size
     // of a pointer).
-    if (valobj_size && size > *valobj_size) {
+    if (valobj_size && size != *valobj_size) {
       auto type_system = compiler_type.GetTypeSystem();
       if (type_system) {
-        CompilerType clang_uint8_type =
-            type_system->GetBuiltinTypeForEncodingAndBitSize(eEncodingUint, 8);
-        compiler_type = clang_uint8_type.GetArrayType(size);
+        if (size <= target.GetArchitecture().GetAddressByteSize()) {
+          compiler_type = type_system->GetBuiltinTypeForEncodingAndBitSize(
+          eEncodingUint, 8 * size);
+        } else {
+          CompilerType clang_uint8_type =
+              type_system->GetBuiltinTypeForEncodingAndBitSize(eEncodingUint, 8);
+          compiler_type = clang_uint8_type.GetArrayType(size);
+        }
       }
     }
 


### PR DESCRIPTION
Fixes issue 

- #153 

Without fix:

```
(lldb) target create "3"
Current executable set to '/home/Watchpoint/3' (powerpc64).
(lldb) b main
Breakpoint 1: where = 3`main + 28 at 3.c:4, address = 0x00000001000008bc
(lldb) r
Process 23986638 launched: '/home/Watchpoint/3' (powerpc64)
Process 23986638 stopped

thread https://github.com/DhruvSrivastavaX/lldb-for-aix/pull/1, name = '3', stop reason = breakpoint 1.1
frame #0: 0x00000001000008bc 3`main at 3.c:4
1 #include <stdio.h>
2 int g = 100;
3 int main() {
-> 4 printf("g address: %p, value: %d\n", &g, g);
5 g = 200;
6 g = 300;
7 printf("Final g: %d\n", g);
(lldb) p &g
(int *) 0x0000000110000b18
(lldb) watchpoint set expression -s 4 -- 0x0000000110000b18
Watchpoint created: Watchpoint 1: addr = 0x110000b18 size = 4 state = enabled type = m
watchpoint spec = '0x0000000110000b18'
watchpoint resources:
#0: addr = 0x110000b18 size = 4
Watchpoint 1 hit:
new value: 429496729600
(lldb) c
Process 23986638 resuming
g address: 110000b18, value: 100

Watchpoint 1 hit:
old value: 429496729600 =================>>>>> WRONG! Should be 100
new value: 858993459200 =================>>>>> WRONG! Should be 200
Process 23986638 stopped

thread https://github.com/DhruvSrivastavaX/lldb-for-aix/pull/1, name = '3', stop reason = watchpoint 1
frame #0: 0x00000001000008e4 3`main at 3.c:6
3 int main() {
4 printf("g address: %p, value: %d\n", &g, g);
5 g = 200;
-> 6 g = 300;
7 printf("Final g: %d\n", g);
8 return 0;
9 }
(lldb) q
Quitting LLDB will kill one or more processes. Do you really want to proceed: [Y/n] y
```

With fix:
Adds a warning:
```
# bin/lldb ../tests/global
(lldb) target create "../tests/global"
Current executable set to '/home/dhruv/dio_fs/LLDB/tests/global' (powerpc64).
(lldb) b main
Breakpoint 1: where = global`main + 12 at global.c:4, address = 0x000000010000092c
(lldb) r
Process 9896326 launched: '/home/dhruv/dio_fs/LLDB/tests/global' (powerpc64)
Process 9896326 stopped
* thread #1, name = 'global', stop reason = breakpoint 1.1
      frame #0: 0x000000010000092c global`main at global.c:4
   1     int g = 5;
   2     int main()
   3     {
-> 4             int x = 10;
   5             int y = x - (--g);
   6             return y;
   7     }
(lldb) watchpoint set expression -- &count^C
bck:e

(lldb) p &g
(int *) 0x0000000110000b68
(lldb) ^C
bck:

(lldb) watchpoint set expression -- 0x0000000110000b68
Watchpoint created: Watchpoint 1: addr = 0x110000b68 size = 8 state = enabled type = m
    watchpoint spec = '0x0000000110000b68'
    watchpoint resources:
       #0: addr = 0x110000b68 size = 8
Watchpoint 1 hit:
    
new value: 21474836480
warning: Cannot infer watchpoint size from expression. Defaulting to pointer size. 
Use -s option to specify size explicitly.
(lldb) q
```

Fixes the usecase:
Case 1:
```
(lldb) watchpoint set expression -s 4 -- 0x0000000110000b68
Watchpoint created: Watchpoint 1: addr = 0x110000b68 size = 4 state = enabled type = m
    watchpoint spec = '0x0000000110000b68'
    watchpoint resources:
       #0: addr = 0x110000b68 size = 4
Watchpoint 1 hit:
    
new value: 5
(lldb) c
Process 9896328 resuming

Watchpoint 1 hit:
old value: 5
new value: 4
Process 9896328 stopped
* thread #1, name = 'global', stop reason = watchpoint 1
      frame #0: 0x0000000100000944 global`main at global.c:5
   2     int main()
   3     {
   4             int x = 10;
-> 5             int y = x - (--g);
   6             return y;
   7     }
```
Case 2:
```
# bin/lldb ../tests/global
(lldb) target create "../tests/global"
Current executable set to '/home/dhruv/dio_fs/LLDB/tests/global' (powerpc64).
(lldb) b main
Breakpoint 1: where = global`main + 12 at global.c:4, address = 0x000000010000092c
(lldb) r
Process 9896330 launched: '/home/dhruv/dio_fs/LLDB/tests/global' (powerpc64)
Process 9896330 stopped
* thread #1, name = 'global', stop reason = breakpoint 1.1
      frame #0: 0x000000010000092c global`main at global.c:4
   1     int g = 5;
   2     int main()
   3     {
-> 4             int x = 10;
   5             int y = x - (--g);
   6             return y;
   7     }
(lldb) watchpoint set expression -- &g
Watchpoint created: Watchpoint 1: addr = 0x110000b68 size = 4 state = enabled type = m
    watchpoint spec = '&g'
    watchpoint resources:
       #0: addr = 0x110000b68 size = 4
Watchpoint 1 hit:
    
new value: 5
(lldb) c
Process 9896330 resuming

Watchpoint 1 hit:
old value: 5
new value: 4
Process 9896330 stopped
* thread #1, name = 'global', stop reason = watchpoint 1
      frame #0: 0x0000000100000944 global`main at global.c:5
   2     int main()
   3     {
   4             int x = 10;
-> 5             int y = x - (--g);
   6             return y;
   7     }

```