### PR TITLE
extractor_sp update for ObjectfileAIXCore

### DIFF
--- a/lldb/source/Plugins/ObjectFile/AIXCore/ObjectFileAIXCore.cpp
+++ b/lldb/source/Plugins/ObjectFile/AIXCore/ObjectFileAIXCore.cpp
@@ -73,7 +73,7 @@ ObjectFile *ObjectFileAIXCore::CreateInstance(const lldb::ModuleSP &module_sp,
           extractor_sp = std::make_shared<lldb_private::DataExtractor>(data_sp);
       }
 
-      //assert(data_sp);
+      assert(extractor_sp && extractor_sp->HasData());
 
       // Update the data to contain the entire file if it doesn't already
       if (extractor_sp->GetByteSize() < length) {
@@ -82,12 +82,15 @@ ObjectFile *ObjectFileAIXCore::CreateInstance(const lldb::ModuleSP &module_sp,
               return nullptr;
           data_offset = 0;
           mapped_writable = true;
+          extractor_sp = std::make_shared<lldb_private::DataExtractor>(data_sp);
       }
 
       // If we didn't map the data as writable take ownership of the buffer.
       if (!mapped_writable) {
-          DataBufferSP data_sp = std::make_shared<DataBufferHeap>(data_sp->GetBytes(),
-                  data_sp->GetByteSize());
+          DataBufferSP new_buffer = std::make_shared<DataBufferHeap>(
+              extractor_sp->GetData().GetBytes(),
+              extractor_sp->GetByteSize());
+          extractor_sp = std::make_shared<lldb_private::DataExtractor>(new_buffer);
           data_offset = 0;
       }
 


### PR DESCRIPTION
Fixes the regerssion:

```
# bin/lldb -c /home/dhruv/tests_DBX/core
(lldb) target create --core "/home/dhruv/tests_DBX/core"
Core file '/home/dhruv/tests_DBX/core' (powerpc64) was loaded.
(lldb) bt
* thread #1, name = 'TS021241538', stop reason = SIGSEGV
  * frame #0: 0x0000000100000948 TS021241538`level3(value=3) at TS021241538.cpp:11
    frame #1: 0x00000001000009dc TS021241538`level2(value=2) at TS021241538.cpp:20
    frame #2: 0x0000000100000a5c TS021241538`level1(value=1) at TS021241538.cpp:26
    frame #3: 0x0000000100000ad0 TS021241538`main at TS021241538.cpp:32
    frame #4: 0x00000001000004ac TS021241538`__start + 116
(lldb) q
```