### PR TITLE
Fix for path resolution when attaching to a process

### DIFF
--- a/lldb/source/Host/aix/Host.cpp
+++ b/lldb/source/Host/aix/Host.cpp
@@ -96,6 +96,8 @@ static std::string ResolveExecutablePath(llvm::StringRef exe_path,
                                          ::pid_t pid) {
   Log *log = GetLog(LLDBLog::Host);
   std::string resolved_path = exe_path.str();
+  char cwd[PATH_MAX];
+  char real_path[PATH_MAX];
 
   // If resolved_path is already absolute, use it directly
   if (!resolved_path.empty() && resolved_path[0] == '/') {
@@ -104,14 +106,12 @@ static std::string ResolveExecutablePath(llvm::StringRef exe_path,
   }
 
   // Try to resolve using the process's cwd
-  char cwd[PATH_MAX];
   std::string cwd_link = "/proc/" + std::to_string(pid) + "/cwd";
   ssize_t len = readlink(cwd_link.c_str(), cwd, sizeof(cwd) - 1);
 
   if (len > 0) {
     cwd[len] = '\0';
-    std::string full_path = std::string(cwd) + "/" + exe_path.str();
-    char real_path[PATH_MAX];
+    std::string full_path = std::string(cwd) + exe_path.str();
 
     if (realpath(full_path.c_str(), real_path) != nullptr) {
       resolved_path = real_path;
@@ -121,7 +121,6 @@ static std::string ResolveExecutablePath(llvm::StringRef exe_path,
   }
 
   // If still not resolved, try realpath on the relative path
-  char real_path[PATH_MAX];
   if (realpath(exe_path.str().c_str(), real_path) != nullptr) {
     resolved_path = real_path;
     LLDB_LOG(log, "Resolved executable path via realpath: {0}", resolved_path);

--- a/lldb/source/Host/aix/Host.cpp
+++ b/lldb/source/Host/aix/Host.cpp
@@ -92,6 +92,45 @@ static bool GetStatusInfo(::pid_t pid, ProcessInstanceInfo &processInfo,
   return true;
 }
 
+static std::string ResolveExecutablePath(llvm::StringRef exe_path,
+                                         ::pid_t pid) {
+  Log *log = GetLog(LLDBLog::Host);
+  std::string resolved_path = exe_path.str();
+
+  // If resolved_path is already absolute, use it directly
+  if (!resolved_path.empty() && resolved_path[0] == '/') {
+    LLDB_LOG(log, "Path is already absolute: {0}", resolved_path);
+    return resolved_path;
+  }
+
+  // Try to resolve using the process's cwd
+  char cwd[PATH_MAX];
+  std::string cwd_link = "/proc/" + std::to_string(pid) + "/cwd";
+  ssize_t len = readlink(cwd_link.c_str(), cwd, sizeof(cwd) - 1);
+
+  if (len > 0) {
+    cwd[len] = '\0';
+    std::string full_path = std::string(cwd) + "/" + exe_path.str();
+    char real_path[PATH_MAX];
+
+    if (realpath(full_path.c_str(), real_path) != nullptr) {
+      resolved_path = real_path;
+      LLDB_LOG(log, "Resolved executable path via cwd: {0}", resolved_path);
+      return resolved_path;
+    }
+  }
+
+  // If still not resolved, try realpath on the relative path
+  char real_path[PATH_MAX];
+  if (realpath(exe_path.str().c_str(), real_path) != nullptr) {
+    resolved_path = real_path;
+    LLDB_LOG(log, "Resolved executable path via realpath: {0}", resolved_path);
+    return resolved_path;
+  }
+
+  return resolved_path;
+}
+
 static ArchSpec GetXCOFFProcessCPUType(llvm::StringRef exe_path) {
   Log *log = GetLog(LLDBLog::Host);
 
@@ -141,8 +180,11 @@ static bool GetExePathAndIds(::pid_t pid, ProcessInstanceInfo &process_info) {
   if (PathRef.empty())
     return false;
 
-  process_info.GetExecutableFile().SetFile(PathRef, FileSpec::Style::native);
-  ArchSpec arch_spec = GetXCOFFProcessCPUType(PathRef);
+  // Resolve the executable path to an absolute path
+  std::string resolved_path = ResolveExecutablePath(PathRef, pid);
+  process_info.GetExecutableFile().SetFile(resolved_path,
+                                           FileSpec::Style::native);
+  ArchSpec arch_spec = GetXCOFFProcessCPUType(resolved_path);
   if (!arch_spec)
     return false;
   process_info.SetArchitecture(arch_spec);

--- a/lldb/source/Plugins/DynamicLoader/AIX-DYLD/DynamicLoaderAIXDYLD.cpp
+++ b/lldb/source/Plugins/DynamicLoader/AIX-DYLD/DynamicLoaderAIXDYLD.cpp
@@ -187,6 +187,15 @@ void DynamicLoaderAIXDYLD::ResolveExecutableModule(
       LLDB_LOGF(log, "Realpath error: Unable to resolve. ");
   }
   
+  if(path_resolved == false) {
+    std::string exe_path(psinfo.pr_psargs);
+    std::string full_path = std::string(cwd) + exe_path.c_str();
+    if (realpath(full_path.c_str(), resolved_path) != nullptr) {
+      LLDB_LOG(log, "Resolved executable path via real path : {0}", resolved_path);
+      path_resolved = true;
+    }
+  }
+
   executable_name = resolved_path;
   if(path_resolved == false) {
       std::string command_line(psinfo.pr_psargs);


### PR DESCRIPTION
Fix an issue When attaching from a different working directory, LLDB was unable to correctly locate the executable and associated source files.

Without Fix
```
(0) root @ unobosdev001: /LLDB/hemang/aix-pre-release-22.1.2.0/bin
# ./while1_test &
[1] 25559428

(0) root @ unobosdev001: /LLDB/hemang/aix-pre-release-22.1.2.0/bin
# cd test

(0) root @ unobosdev001: /LLDB/hemang/aix-pre-release-22.1.2.0/bin/test
# ../lldb -p 25559428
(lldb) process attach --pid 25559428
Process 25559428 stopped
* thread #1, name = 'while1_test', stop reason = signal SIGSTOP
      frame #0: 0x80000000 
error: memory read failed for 0x80000000
Executable binary set to "/LLDB/hemang/aix-pre-release-22.1.2.0/bin/while1_test".
Architecture set to: powerpc-ibm-aix.
```

With Fix :
```
(0) root @ unobosdev001: /LLDB/hemang/build_1
# cdbuild

(0) root @ unobosdev001: /LLDB/hemang/build_1
# bin/lldb -p 25559428
(lldb) process attach --pid 25559428
Process 25559428 stopped
* thread #1, name = 'while1_test', stop reason = signal SIGSTOP
      frame #0: 0x0000000100000930 while1_test`main at while1.c:4
   1     int main()
   2     {
   3         int a = 10;
-> 4         while(1);
   5         return 1;
   6     }
Executable binary set to "/LLDB/hemang/aix-pre-release-22.1.2.0/bin/while1_test".
Architecture set to: powerpc64-ibm-aix7.3.0.0.
```

Tested with all below scenarios

```
 22151472 pts/15 29:33 /LLDB/hemang/aix-pre-release-22.1.2.0/bin/while1_test 
 25100668 pts/15 28:07 aix-pre-release-22.1.2.0/bin/while1_test 
 25297386 pts/15 29:43 ./while1_test 
 25821448 pts/15  6:17 ../../while1_test_32 
 32375284 pts/15 29:00 ../../while1_test 
 33685952 pts/15 27:29 while1_test 
 35782918 pts/15 23:54 ../while1_test 
```
