### PR TITLE
Design change support for coredump

### DIFF
--- a/lldb/source/Plugins/ObjectFile/AIXCore/ObjectFileAIXCore.cpp
+++ b/lldb/source/Plugins/ObjectFile/AIXCore/ObjectFileAIXCore.cpp
@@ -41,6 +41,7 @@ LLDB_PLUGIN_DEFINE(ObjectFileAIXCore)
 enum CoreVersion : uint64_t {AIXCORE32 = 0xFEEDDB1, AIXCORE64 = 0xFEEDDB2};
 
 bool m_is_core = false;
+bool m_is32bit = false;
 
 // Static methods.
 void ObjectFileAIXCore::Initialize() {
@@ -116,10 +117,14 @@ ModuleSpecList ObjectFileAIXCore::GetModuleSpecifications(
 
   ModuleSpecList specs;
   if (ObjectFileAIXCore::MagicBytesMatch(extractor_sp, 0, extractor_sp->GetByteSize())) {
+      printf("m_is32 %d\n", m_is32bit);
+    const uint32_t cpu_type =
+        (m_is32bit) ? XCOFF::TCPU_PPC : XCOFF::TCPU_PPC64;
+    printf("cpu_type %d\n",cpu_type);
     // Need new ArchType???
-    ArchSpec arch_spec = ArchSpec(eArchTypeXCOFF, XCOFF::TCPU_PPC64, LLDB_INVALID_CPUTYPE);
+    ArchSpec arch_spec = ArchSpec(eArchTypeXCOFF, cpu_type, LLDB_INVALID_CPUTYPE);
     ModuleSpec spec(file, arch_spec);
-    spec.GetArchitecture().SetArchitecture(eArchTypeXCOFF, XCOFF::TCPU_PPC64, LLDB_INVALID_CPUTYPE, llvm::Triple::AIX);
+    spec.GetArchitecture().SetArchitecture(eArchTypeXCOFF, cpu_type, LLDB_INVALID_CPUTYPE, llvm::Triple::AIX);
     specs.Append(spec);
   }
   return specs;
@@ -131,6 +136,7 @@ static bool AIXCoreHeaderCheckFromMagic(uint32_t magic) {
     bool ret = false;
     switch (magic) {
         case AIXCORE32: 
+            m_is32bit = true;
         case AIXCORE64:
             m_is_core = true;
             ret = true; 
@@ -164,6 +170,8 @@ bool ObjectFileAIXCore::IsExecutable() const {
 }
 
 uint32_t ObjectFileAIXCore::GetAddressByteSize() const {
+    if (m_is32bit)
+        return 4;
     return 8;
 }
 

--- a/lldb/source/Plugins/ObjectFile/AIXCore/ObjectFileAIXCore.cpp
+++ b/lldb/source/Plugins/ObjectFile/AIXCore/ObjectFileAIXCore.cpp
@@ -117,10 +117,8 @@ ModuleSpecList ObjectFileAIXCore::GetModuleSpecifications(
 
   ModuleSpecList specs;
   if (ObjectFileAIXCore::MagicBytesMatch(extractor_sp, 0, extractor_sp->GetByteSize())) {
-      printf("m_is32 %d\n", m_is32bit);
     const uint32_t cpu_type =
         (m_is32bit) ? XCOFF::TCPU_PPC : XCOFF::TCPU_PPC64;
-    printf("cpu_type %d\n",cpu_type);
     // Need new ArchType???
     ArchSpec arch_spec = ArchSpec(eArchTypeXCOFF, cpu_type, LLDB_INVALID_CPUTYPE);
     ModuleSpec spec(file, arch_spec);
@@ -201,7 +199,9 @@ void ObjectFileAIXCore::Dump(Stream *s) {
 }
 
 ArchSpec ObjectFileAIXCore::GetArchitecture() {
-  ArchSpec arch_spec = ArchSpec(eArchTypeXCOFF, XCOFF::TCPU_PPC64, LLDB_INVALID_CPUTYPE);
+    const uint32_t cpu_type =
+        (m_is32bit) ? XCOFF::TCPU_PPC : XCOFF::TCPU_PPC64;
+  ArchSpec arch_spec = ArchSpec(eArchTypeXCOFF, cpu_type, LLDB_INVALID_CPUTYPE);
   return arch_spec;
 }
 

--- a/lldb/source/Plugins/Process/Utility/CMakeLists.txt
+++ b/lldb/source/Plugins/Process/Utility/CMakeLists.txt
@@ -46,6 +46,7 @@ add_lldb_library(lldbPluginProcessUtility
   RegisterContextPOSIX_riscv32.cpp
   RegisterContextPOSIX_powerpc.cpp
   RegisterContextPOSIX_ppc64le.cpp
+  RegisterContextPOSIX_ppc64.cpp
   RegisterContextPOSIX_riscv64.cpp
   RegisterContextPOSIX_s390x.cpp
   RegisterContextPOSIX_x86.cpp

--- a/lldb/source/Plugins/Process/Utility/RegisterContextPOSIX_ppc64.cpp
+++ b/lldb/source/Plugins/Process/Utility/RegisterContextPOSIX_ppc64.cpp
@@ -1,0 +1,170 @@
+//===-- RegisterContextPOSIX_ppc64.cpp ------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "RegisterContextPOSIX_ppc64.h"
+#include "lldb/Utility/DataBufferHeap.h"
+#include "lldb/Utility/RegisterValue.h"
+#include "lldb/Utility/Status.h"
+#include <cerrno>
+#include <cstdint>
+#include <cstring>
+
+using namespace lldb;
+using namespace lldb_private;
+
+static const uint32_t g_gpr_regnums_ppc64[] = {
+    gpr_r0_ppc64,  gpr_r1_ppc64,  gpr_r2_ppc64,  gpr_r3_ppc64,  gpr_r4_ppc64,
+    gpr_r5_ppc64,  gpr_r6_ppc64,  gpr_r7_ppc64,  gpr_r8_ppc64,  gpr_r9_ppc64,
+    gpr_r10_ppc64, gpr_r11_ppc64, gpr_r12_ppc64, gpr_r13_ppc64, gpr_r14_ppc64,
+    gpr_r15_ppc64, gpr_r16_ppc64, gpr_r17_ppc64, gpr_r18_ppc64, gpr_r19_ppc64,
+    gpr_r20_ppc64, gpr_r21_ppc64, gpr_r22_ppc64, gpr_r23_ppc64, gpr_r24_ppc64,
+    gpr_r25_ppc64, gpr_r26_ppc64, gpr_r27_ppc64, gpr_r28_ppc64, gpr_r29_ppc64,
+    gpr_r30_ppc64, gpr_r31_ppc64, gpr_cr_ppc64,  gpr_msr_ppc64, gpr_xer_ppc64,
+    gpr_lr_ppc64,  gpr_ctr_ppc64, gpr_pc_ppc64,
+};
+
+static const uint32_t g_fpr_regnums_ppc64[] = {
+    fpr_f0_ppc64,  fpr_f1_ppc64,  fpr_f2_ppc64,    fpr_f3_ppc64,  fpr_f4_ppc64,
+    fpr_f5_ppc64,  fpr_f6_ppc64,  fpr_f7_ppc64,    fpr_f8_ppc64,  fpr_f9_ppc64,
+    fpr_f10_ppc64, fpr_f11_ppc64, fpr_f12_ppc64,   fpr_f13_ppc64, fpr_f14_ppc64,
+    fpr_f15_ppc64, fpr_f16_ppc64, fpr_f17_ppc64,   fpr_f18_ppc64, fpr_f19_ppc64,
+    fpr_f20_ppc64, fpr_f21_ppc64, fpr_f22_ppc64,   fpr_f23_ppc64, fpr_f24_ppc64,
+    fpr_f25_ppc64, fpr_f26_ppc64, fpr_f27_ppc64,   fpr_f28_ppc64, fpr_f29_ppc64,
+    fpr_f30_ppc64, fpr_f31_ppc64, fpr_fpscr_ppc64,
+};
+
+static const uint32_t g_vmx_regnums_ppc64[] = {
+    vmx_vr0_ppc64,  vmx_vr1_ppc64,    vmx_vr2_ppc64,  vmx_vr3_ppc64,
+    vmx_vr4_ppc64,  vmx_vr5_ppc64,    vmx_vr6_ppc64,  vmx_vr7_ppc64,
+    vmx_vr8_ppc64,  vmx_vr9_ppc64,    vmx_vr10_ppc64, vmx_vr11_ppc64,
+    vmx_vr12_ppc64, vmx_vr13_ppc64,   vmx_vr14_ppc64, vmx_vr15_ppc64,
+    vmx_vr16_ppc64, vmx_vr17_ppc64,   vmx_vr18_ppc64, vmx_vr19_ppc64,
+    vmx_vr20_ppc64, vmx_vr21_ppc64,   vmx_vr22_ppc64, vmx_vr23_ppc64,
+    vmx_vr24_ppc64, vmx_vr25_ppc64,   vmx_vr26_ppc64, vmx_vr27_ppc64,
+    vmx_vr28_ppc64, vmx_vr29_ppc64,   vmx_vr30_ppc64, vmx_vr31_ppc64,
+    vmx_vscr_ppc64, vmx_vrsave_ppc64,
+};
+
+static const uint32_t g_vsx_regnums_ppc64[] = {
+    vsx_vs0_ppc64,  vsx_vs1_ppc64,  vsx_vs2_ppc64,  vsx_vs3_ppc64,
+    vsx_vs4_ppc64,  vsx_vs5_ppc64,  vsx_vs6_ppc64,  vsx_vs7_ppc64,
+    vsx_vs8_ppc64,  vsx_vs9_ppc64,  vsx_vs10_ppc64, vsx_vs11_ppc64,
+    vsx_vs12_ppc64, vsx_vs13_ppc64, vsx_vs14_ppc64, vsx_vs15_ppc64,
+    vsx_vs16_ppc64, vsx_vs17_ppc64, vsx_vs18_ppc64, vsx_vs19_ppc64,
+    vsx_vs20_ppc64, vsx_vs21_ppc64, vsx_vs22_ppc64, vsx_vs23_ppc64,
+    vsx_vs24_ppc64, vsx_vs25_ppc64, vsx_vs26_ppc64, vsx_vs27_ppc64,
+    vsx_vs28_ppc64, vsx_vs29_ppc64, vsx_vs30_ppc64, vsx_vs31_ppc64,
+    vsx_vs32_ppc64, vsx_vs33_ppc64, vsx_vs34_ppc64, vsx_vs35_ppc64,
+    vsx_vs36_ppc64, vsx_vs37_ppc64, vsx_vs38_ppc64, vsx_vs39_ppc64,
+    vsx_vs40_ppc64, vsx_vs41_ppc64, vsx_vs42_ppc64, vsx_vs43_ppc64,
+    vsx_vs44_ppc64, vsx_vs45_ppc64, vsx_vs46_ppc64, vsx_vs47_ppc64,
+    vsx_vs48_ppc64, vsx_vs49_ppc64, vsx_vs50_ppc64, vsx_vs51_ppc64,
+    vsx_vs52_ppc64, vsx_vs53_ppc64, vsx_vs54_ppc64, vsx_vs55_ppc64,
+    vsx_vs56_ppc64, vsx_vs57_ppc64, vsx_vs58_ppc64, vsx_vs59_ppc64,
+    vsx_vs60_ppc64, vsx_vs61_ppc64, vsx_vs62_ppc64, vsx_vs63_ppc64,
+};
+
+// Number of register sets provided by this context.
+static constexpr int k_num_register_sets = 4;
+
+static const RegisterSet g_reg_sets_ppc64[k_num_register_sets] = {
+    {"General Purpose Registers", "gpr", k_num_gpr_registers_ppc64,
+     g_gpr_regnums_ppc64},
+    {"Floating Point Registers", "fpr", k_num_fpr_registers_ppc64,
+     g_fpr_regnums_ppc64},
+    {"AltiVec/VMX Registers", "vmx", k_num_vmx_registers_ppc64,
+     g_vmx_regnums_ppc64},
+    {"VSX Registers", "vsx", k_num_vsx_registers_ppc64, g_vsx_regnums_ppc64},
+};
+
+bool RegisterContextPOSIX_ppc64::IsGPR(unsigned reg) {
+  return reg <= k_last_gpr_ppc64; // GPR's come first.
+}
+
+bool RegisterContextPOSIX_ppc64::IsFPR(unsigned reg) {
+  return (k_first_fpr_ppc64 <= reg && reg <= k_last_fpr_ppc64);
+}
+
+bool RegisterContextPOSIX_ppc64::IsVMX(unsigned reg) {
+  return (reg >= k_first_vmx_ppc64) && (reg <= k_last_vmx_ppc64);
+}
+
+bool RegisterContextPOSIX_ppc64::IsVSX(unsigned reg) {
+  return (reg >= k_first_vsx_ppc64) && (reg <= k_last_vsx_ppc64);
+}
+
+RegisterContextPOSIX_ppc64::RegisterContextPOSIX_ppc64(
+    Thread &thread, uint32_t concrete_frame_idx,
+    RegisterInfoInterface *register_info)
+    : RegisterContext(thread, concrete_frame_idx) {
+  m_register_info_up.reset(register_info);
+}
+
+void RegisterContextPOSIX_ppc64::InvalidateAllRegisters() {}
+
+unsigned RegisterContextPOSIX_ppc64::GetRegisterOffset(unsigned reg) {
+  assert(reg < k_num_registers_ppc64 && "Invalid register number.");
+  return GetRegisterInfo()[reg].byte_offset;
+}
+
+unsigned RegisterContextPOSIX_ppc64::GetRegisterSize(unsigned reg) {
+  assert(reg < k_num_registers_ppc64 && "Invalid register number.");
+  return GetRegisterInfo()[reg].byte_size;
+}
+
+size_t RegisterContextPOSIX_ppc64::GetRegisterCount() {
+  size_t num_registers = k_num_registers_ppc64;
+  return num_registers;
+}
+
+size_t RegisterContextPOSIX_ppc64::GetGPRSize() {
+  return m_register_info_up->GetGPRSize();
+}
+
+const RegisterInfo *RegisterContextPOSIX_ppc64::GetRegisterInfo() {
+  // Commonly, this method is overridden and g_register_infos is copied and
+  // specialized. So, use GetRegisterInfo() rather than g_register_infos in
+  // this scope.
+  return m_register_info_up->GetRegisterInfo();
+}
+
+const RegisterInfo *
+RegisterContextPOSIX_ppc64::GetRegisterInfoAtIndex(size_t reg) {
+  if (reg < k_num_registers_ppc64)
+    return &GetRegisterInfo()[reg];
+  else
+    return nullptr;
+}
+
+size_t RegisterContextPOSIX_ppc64::GetRegisterSetCount() {
+  size_t sets = 0;
+  for (size_t set = 0; set < k_num_register_sets; ++set) {
+    if (IsRegisterSetAvailable(set))
+      ++sets;
+  }
+
+  return sets;
+}
+
+const RegisterSet *RegisterContextPOSIX_ppc64::GetRegisterSet(size_t set) {
+  if (IsRegisterSetAvailable(set))
+    return &g_reg_sets_ppc64[set];
+  else
+    return nullptr;
+}
+
+const char *RegisterContextPOSIX_ppc64::GetRegisterName(unsigned reg) {
+  assert(reg < k_num_registers_ppc64 && "Invalid register offset.");
+  return GetRegisterInfo()[reg].name;
+}
+
+bool RegisterContextPOSIX_ppc64::IsRegisterSetAvailable(size_t set_index) {
+  size_t num_sets = k_num_register_sets;
+
+  return (set_index < num_sets);
+}

--- a/lldb/source/Plugins/Process/Utility/RegisterContextPOSIX_ppc64.h
+++ b/lldb/source/Plugins/Process/Utility/RegisterContextPOSIX_ppc64.h
@@ -1,0 +1,71 @@
+//===-- RegisterContextPOSIX_ppc64.h ----------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLDB_SOURCE_PLUGINS_PROCESS_UTILITY_REGISTERCONTEXTPOSIX_PPC64_H
+#define LLDB_SOURCE_PLUGINS_PROCESS_UTILITY_REGISTERCONTEXTPOSIX_PPC64_H
+
+#include "Plugins/Process/Utility/lldb-ppc64-register-enums.h"
+#include "RegisterInfoInterface.h"
+#include "Utility/PPC64_DWARF_Registers.h"
+#include "lldb/Target/RegisterContext.h"
+#include "lldb/Utility/Log.h"
+
+class RegisterContextPOSIX_ppc64 : public lldb_private::RegisterContext {
+public:
+  RegisterContextPOSIX_ppc64(
+      lldb_private::Thread &thread, uint32_t concrete_frame_idx,
+      lldb_private::RegisterInfoInterface *register_info);
+
+  void InvalidateAllRegisters() override;
+
+  size_t GetRegisterCount() override;
+
+  virtual size_t GetGPRSize();
+
+  virtual unsigned GetRegisterSize(unsigned reg);
+
+  virtual unsigned GetRegisterOffset(unsigned reg);
+
+  const lldb_private::RegisterInfo *GetRegisterInfoAtIndex(size_t reg) override;
+
+  size_t GetRegisterSetCount() override;
+
+  const lldb_private::RegisterSet *GetRegisterSet(size_t set) override;
+
+  const char *GetRegisterName(unsigned reg);
+
+protected:
+  // 64-bit general purpose registers.
+  uint64_t m_gpr_ppc64[k_num_gpr_registers_ppc64];
+
+  // floating-point registers including extended register.
+  uint64_t m_fpr_ppc64[k_num_fpr_registers_ppc64];
+
+  // VMX registers.
+  uint64_t m_vmx_ppc64[k_num_vmx_registers_ppc64 * 2];
+
+  // VSX registers.
+  uint64_t m_vsx_ppc64[k_num_vsx_registers_ppc64 * 2];
+
+  std::unique_ptr<lldb_private::RegisterInfoInterface> m_register_info_up;
+
+  // Determines if an extended register set is supported on the processor
+  // running the inferior process.
+  virtual bool IsRegisterSetAvailable(size_t set_index);
+
+  virtual const lldb_private::RegisterInfo *GetRegisterInfo();
+
+  bool IsGPR(unsigned reg);
+
+  bool IsFPR(unsigned reg);
+
+  bool IsVMX(unsigned reg);
+
+  bool IsVSX(unsigned reg);
+};
+#endif // LLDB_SOURCE_PLUGINS_PROCESS_UTILITY_REGISTERCONTEXTPOSIX_PPC64_H

--- a/lldb/source/Plugins/Process/aix-core/AIXCore.cpp
+++ b/lldb/source/Plugins/Process/aix-core/AIXCore.cpp
@@ -28,16 +28,16 @@ AIXCore32Header::AIXCore32Header() { memset(this, 0, sizeof(AIXCore32Header)); }
 
 bool AIXCore32Header::ParseRegisterContext(lldb_private::DataExtractor &data,
                 lldb::offset_t *offset) {
-    Log *log = GetLog(LLDBLog::Process);
     *offset += 20; // skip till curid in mstsave32
+   
     Fault.context.excp_type = data.GetU32(offset);
     Fault.context.pc = data.GetU32(offset);
-    LLDB_LOG(log, "pc {0:x}", Fault.context.pc);
     Fault.context.msr = data.GetU32(offset);
     Fault.context.cr = data.GetU32(offset);
     Fault.context.lr = data.GetU32(offset);
     Fault.context.ctr = data.GetU32(offset);
     Fault.context.xer = data.GetU32(offset);
+   
     // need to skip 0-39 U32s after this upto gpr
     /* *offset += 8; // mq, tid
     Fault.context.fpscr = data.GetU32(offset);
@@ -45,15 +45,16 @@ bool AIXCore32Header::ParseRegisterContext(lldb_private::DataExtractor &data,
     Fault.context.fpinfo = data.GetU8(offset);
     Fault.context.fpscr24_31 = data.GetU8(offset);
     */
+   
     // Skipping unneeded data
     for(int i = 0; i < 40; i++)
         data.GetU32(offset);
     for(int i = 0; i < 32; i++) {
         Fault.context.gpr[i] = data.GetU32(offset);
-        LLDB_LOG(log, "gpr {0} {1:x}",i,Fault.context.gpr[i]);
     }
     for(int i = 0; i < 32; i++)
         Fault.context.fpr[i] = data.GetU32(offset);
+  
     return true;
 }
 
@@ -136,12 +137,11 @@ bool AIXCore64Header::ParseRegisterContext(lldb_private::DataExtractor &data,
     // The data is arranged in this order in this coredump file
     // so we have to fetch in this exact order. But need to change
     // the context structure order according to Infos_ppc64
-    Log *log = GetLog(LLDBLog::Process);
     for(int i = 0; i < 32; i++)
         Fault.context.gpr[i] = data.GetU64(offset);
+    
     Fault.context.msr = data.GetU64(offset); 
     Fault.context.pc = data.GetU64(offset); 
-    LLDB_LOG(log, "pc {0}", Fault.context.pc);
     Fault.context.lr = data.GetU64(offset); 
     Fault.context.ctr = data.GetU64(offset); 
     Fault.context.cr = data.GetU32(offset); 
@@ -149,8 +149,10 @@ bool AIXCore64Header::ParseRegisterContext(lldb_private::DataExtractor &data,
     Fault.context.fpscr = data.GetU32(offset); 
     Fault.context.fpscrx = data.GetU32(offset); 
     Fault.context.except[0] = data.GetU64(offset); 
+    
     for(int i = 0; i < 32; i++)
         Fault.context.fpr[i] = data.GetU64(offset);
+    
     Fault.context.fpeu = data.GetU8(offset); 
     Fault.context.fpinfo = data.GetU8(offset); 
     Fault.context.fpscr24_31 = data.GetU8(offset); 

--- a/lldb/source/Plugins/Process/aix-core/AIXCore.cpp
+++ b/lldb/source/Plugins/Process/aix-core/AIXCore.cpp
@@ -28,9 +28,11 @@ AIXCore32Header::AIXCore32Header() { memset(this, 0, sizeof(AIXCore32Header)); }
 
 bool AIXCore32Header::ParseRegisterContext(lldb_private::DataExtractor &data,
                 lldb::offset_t *offset) {
+    Log *log = GetLog(LLDBLog::Process);
     *offset += 20; // skip till curid in mstsave32
     Fault.context.excp_type = data.GetU32(offset);
     Fault.context.pc = data.GetU32(offset);
+    LLDB_LOG(log, "pc {0:x}", Fault.context.pc);
     Fault.context.msr = data.GetU32(offset);
     Fault.context.cr = data.GetU32(offset);
     Fault.context.lr = data.GetU32(offset);
@@ -48,6 +50,7 @@ bool AIXCore32Header::ParseRegisterContext(lldb_private::DataExtractor &data,
         data.GetU32(offset);
     for(int i = 0; i < 32; i++) {
         Fault.context.gpr[i] = data.GetU32(offset);
+        LLDB_LOG(log, "gpr {0} {1:x}",i,Fault.context.gpr[i]);
     }
     for(int i = 0; i < 32; i++)
         Fault.context.fpr[i] = data.GetU32(offset);
@@ -121,7 +124,7 @@ bool AIXCore32Header::ParseCoreHeader(lldb_private::DataExtractor &data,
         AIXCore32Header temp_header;
         ThreadContext32 thread;
         temp_header.ParseThreadContext(data, &offset_to_threads);
-        memcpy(&thread, &temp_header.Fault, sizeof(ThreadContext64));
+        memcpy(&thread, &temp_header.Fault, sizeof(ThreadContext32));
         threads.push_back(std::move(thread));
     }
 
@@ -133,10 +136,12 @@ bool AIXCore64Header::ParseRegisterContext(lldb_private::DataExtractor &data,
     // The data is arranged in this order in this coredump file
     // so we have to fetch in this exact order. But need to change
     // the context structure order according to Infos_ppc64
+    Log *log = GetLog(LLDBLog::Process);
     for(int i = 0; i < 32; i++)
         Fault.context.gpr[i] = data.GetU64(offset);
     Fault.context.msr = data.GetU64(offset); 
     Fault.context.pc = data.GetU64(offset); 
+    LLDB_LOG(log, "pc {0}", Fault.context.pc);
     Fault.context.lr = data.GetU64(offset); 
     Fault.context.ctr = data.GetU64(offset); 
     Fault.context.cr = data.GetU32(offset); 

--- a/lldb/source/Plugins/Process/aix-core/AIXCore.h
+++ b/lldb/source/Plugins/Process/aix-core/AIXCore.h
@@ -22,21 +22,40 @@
 namespace AIXCORE {
 
 enum CoreVersion : uint64_t {AIXCORE32 = 0xFEEDDB1, AIXCORE64 = 0xFEEDDB2};
-struct RegContext {
+struct RegContext32 {
+    // The data is arranged in order as filled by AIXCore.cpp in this coredump file
+    // so we have to fetch in that exact order, refer there. 
+    // But need to change
+    // the context structure in order according to Infos_ppc64
+        uint32_t                gpr[32];    /* 64-bit gprs */
+        uint32_t                cr;             /* CR */
+        uint32_t                msr;            /* msr */
+        uint32_t                xer;            /* XER */
+        uint32_t                lr;             /* LR */
+        uint32_t                ctr;            /* CTR */
+        uint32_t                pc;            /* pc */
+        unsigned int            fpscr;          /* floating pt status reg */
+        unsigned int            fpscrx;         /* software ext to fpscr */
+        unsigned long           except[1];      /* exception address    */
+        double                  fpr[32];    /* floating pt regs     */
+        char                    fpeu;           /* floating pt ever used */
+        char                    fpinfo;         /* floating pt info     */
+        char                    fpscr24_31;     /* bits 24-31 of 64-bit FPSCR */
+        char                    pad[1];
+        int                     excp_type;      /* exception type       */
+};
+struct RegContext64 {
     // The data is arranged in order as filled by AIXCore.cpp in this coredump file
     // so we have to fetch in that exact order, refer there. 
     // But need to change
     // the context structure in order according to Infos_ppc64
         uint64_t                gpr[32];    /* 64-bit gprs */
-        unsigned long           pc;            /* msr */
-        unsigned long           msr;            /* iar */
-        unsigned long           origr3;            /* iar */
-        unsigned long           ctr;            /* CTR */
-        unsigned long           lr;             /* LR */
-        unsigned long           xer;            /* XER */
-        unsigned long           cr;             /* CR */
-        unsigned long           softe;             /* CR */
-        unsigned long           trap;             /* CR */
+        uint32_t                cr;             /* CR */
+        uint32_t                xer;            /* XER */
+        uint64_t                msr;            /* msr */
+        uint64_t                lr;             /* LR */
+        uint64_t                ctr;            /* CTR */
+        uint64_t                pc;            /* pc */
         unsigned int            fpscr;          /* floating pt status reg */
         unsigned int            fpscrx;         /* software ext to fpscr */
         unsigned long           except[1];      /* exception address    */
@@ -50,12 +69,13 @@ struct RegContext {
 
     struct ThreadContext64 {
         struct thrdentry64 thread;
-        struct RegContext context;
+        struct RegContext64 context;
     };
 
     struct ThreadContext32 {
         struct thrdsinfo64 thread;
-        struct RegContext context; // This one saves mstsave32 and not context64
+        // It should be RegContext32 but needs some changes before it
+        struct RegContext64 context; // This one saves mstsave32 and not context64
     };
 
     struct UserData {

--- a/lldb/source/Plugins/Process/aix-core/AIXCore.h
+++ b/lldb/source/Plugins/Process/aix-core/AIXCore.h
@@ -75,7 +75,7 @@ struct RegContext64 {
     struct ThreadContext32 {
         struct thrdsinfo64 thread;
         // It should be RegContext32 but needs some changes before it
-        struct RegContext64 context; // This one saves mstsave32 and not context64
+        struct RegContext32 context; // This one saves mstsave32 and not context64
     };
 
     struct UserData {

--- a/lldb/source/Plugins/Process/aix-core/ProcessAIXCore.cpp
+++ b/lldb/source/Plugins/Process/aix-core/ProcessAIXCore.cpp
@@ -247,6 +247,9 @@ void ProcessAIXCore::ParseAIXCoreFile() {
     }
 }
 
+#define DECLARE_REGISTER_INFOS_PPC64_STRUCT
+#include "Plugins/Process/Utility/RegisterInfos_ppc64.h"
+
 void ProcessAIXCore::ParseAIXCore32File() {
     
     Log *log = GetLog(LLDBLog::Process);
@@ -289,7 +292,9 @@ void ProcessAIXCore::ParseAIXCore32File() {
             memcpy(static_cast<void *>(const_cast<uint8_t *>(regs_buf_sp->GetBytes())),
                    &m_aixcore32_header.threads[i-1].context, regs_size);          
         }
-        lldb_private::DataExtractor regs_data(regs_buf_sp, lldb::eByteOrderBig, 8);
+        // For 32-bit, we need to reorder registers to match GPR_PPC layout
+
+        lldb_private::DataExtractor regs_data(regs_buf_sp, lldb::eByteOrderBig, 4);
         thread_data.gpregset = DataExtractor(regs_data, 0, regs_size);          
                                                                                 
         thread_data.prstatus_sig = 0;                                           

--- a/lldb/source/Plugins/Process/aix-core/ProcessAIXCore.cpp
+++ b/lldb/source/Plugins/Process/aix-core/ProcessAIXCore.cpp
@@ -247,9 +247,6 @@ void ProcessAIXCore::ParseAIXCoreFile() {
     }
 }
 
-#define DECLARE_REGISTER_INFOS_PPC64_STRUCT
-#include "Plugins/Process/Utility/RegisterInfos_ppc64.h"
-
 void ProcessAIXCore::ParseAIXCore32File() {
     
     Log *log = GetLog(LLDBLog::Process);
@@ -292,7 +289,6 @@ void ProcessAIXCore::ParseAIXCore32File() {
             memcpy(static_cast<void *>(const_cast<uint8_t *>(regs_buf_sp->GetBytes())),
                    &m_aixcore32_header.threads[i-1].context, regs_size);          
         }
-        // For 32-bit, we need to reorder registers to match GPR_PPC layout
 
         lldb_private::DataExtractor regs_data(regs_buf_sp, lldb::eByteOrderBig, 4);
         thread_data.gpregset = DataExtractor(regs_data, 0, regs_size);          

--- a/lldb/source/Plugins/Process/aix-core/RegisterContextCoreAIX_ppc64.cpp
+++ b/lldb/source/Plugins/Process/aix-core/RegisterContextCoreAIX_ppc64.cpp
@@ -11,8 +11,6 @@
 #include "lldb/Target/Thread.h"
 #include "lldb/Utility/DataBufferHeap.h"
 #include "lldb/Utility/RegisterValue.h"
-#include "lldb/Utility/LLDBLog.h"
-#include "lldb/Utility/Log.h"
 
 #include "Plugins/Process/Utility/lldb-ppc64-register-enums.h"
 #include "Plugins/Process/elf-core/RegisterUtilities.h"
@@ -68,7 +66,6 @@ size_t RegisterContextCoreAIX_ppc64::GetVSXSize() const {
 
 bool RegisterContextCoreAIX_ppc64::ReadRegister(
     const RegisterInfo *reg_info, RegisterValue &value) {
-    Log *log = GetLog(LLDBLog::Process);
 
   lldb::offset_t offset = reg_info->byte_offset;
 
@@ -119,26 +116,6 @@ bool RegisterContextCoreAIX_ppc64::ReadRegister(
         return true;
       }
     }
-/*    } else {
-  // For 32-bit cores, we need to read 32-bit values, not 64-bit
-  // Check the address byte size to determine if this is a 32-bit or 64-bit core
-  uint64_t v;
-  if (m_gpr.GetAddressByteSize() == 4 && reg_info->byte_size == 4) {
-    // 32-bit core: read as 32-bit value
-    v = m_gpr.GetU32(&offset);
-  } else {
-    // 64-bit core or smaller register: use GetMaxU64
-    v = m_gpr.GetMaxU64(&offset, reg_info->byte_size);
-  }
-
-  if (offset == reg_info->byte_offset + reg_info->byte_size) {
-    if (reg_info->byte_size < sizeof(v))
-      value = (uint32_t)v;
-    else
-      value = v;
-    return true;
-  }
-}*/
   } else {
     uint64_t v = m_gpr.GetMaxU64(&offset, reg_info->byte_size);
 

--- a/lldb/source/Plugins/Process/aix-core/RegisterContextCoreAIX_ppc64.cpp
+++ b/lldb/source/Plugins/Process/aix-core/RegisterContextCoreAIX_ppc64.cpp
@@ -11,8 +11,10 @@
 #include "lldb/Target/Thread.h"
 #include "lldb/Utility/DataBufferHeap.h"
 #include "lldb/Utility/RegisterValue.h"
+#include "lldb/Utility/LLDBLog.h"
+#include "lldb/Utility/Log.h"
 
-#include "Plugins/Process/Utility/lldb-ppc64le-register-enums.h"
+#include "Plugins/Process/Utility/lldb-ppc64-register-enums.h"
 #include "Plugins/Process/elf-core/RegisterUtilities.h"
 
 #include <memory>
@@ -22,7 +24,7 @@ using namespace lldb_private;
 RegisterContextCoreAIX_ppc64::RegisterContextCoreAIX_ppc64(
     Thread &thread, RegisterInfoInterface *register_info,
     const DataExtractor &gpregset)
-    : RegisterContextPOSIX_ppc64le(thread, 0, register_info) {
+    : RegisterContextPOSIX_ppc64(thread, 0, register_info) {
   m_gpr_buffer = std::make_shared<DataBufferHeap>(gpregset.GetDataStart(),
                                                   gpregset.GetByteSize());
   m_gpr.SetData(m_gpr_buffer);
@@ -52,20 +54,22 @@ RegisterContextCoreAIX_ppc64::RegisterContextCoreAIX_ppc64(
 }
 
 size_t RegisterContextCoreAIX_ppc64::GetFPRSize() const {
-  return k_num_fpr_registers_ppc64le * sizeof(uint64_t);
+  return k_num_fpr_registers_ppc64 * sizeof(uint64_t);
 }
 
 size_t RegisterContextCoreAIX_ppc64::GetVMXSize() const {
-  return (k_num_vmx_registers_ppc64le - 1) * sizeof(uint64_t) * 2 +
+  return (k_num_vmx_registers_ppc64 - 1) * sizeof(uint64_t) * 2 +
          sizeof(uint32_t);
 }
 
 size_t RegisterContextCoreAIX_ppc64::GetVSXSize() const {
-  return k_num_vsx_registers_ppc64le * sizeof(uint64_t) * 2;
+  return k_num_vsx_registers_ppc64 * sizeof(uint64_t) * 2;
 }
 
 bool RegisterContextCoreAIX_ppc64::ReadRegister(
     const RegisterInfo *reg_info, RegisterValue &value) {
+    Log *log = GetLog(LLDBLog::Process);
+
   lldb::offset_t offset = reg_info->byte_offset;
 
   if (IsFPR(reg_info->kinds[lldb::eRegisterKindLLDB])) {
@@ -115,6 +119,26 @@ bool RegisterContextCoreAIX_ppc64::ReadRegister(
         return true;
       }
     }
+/*    } else {
+  // For 32-bit cores, we need to read 32-bit values, not 64-bit
+  // Check the address byte size to determine if this is a 32-bit or 64-bit core
+  uint64_t v;
+  if (m_gpr.GetAddressByteSize() == 4 && reg_info->byte_size == 4) {
+    // 32-bit core: read as 32-bit value
+    v = m_gpr.GetU32(&offset);
+  } else {
+    // 64-bit core or smaller register: use GetMaxU64
+    v = m_gpr.GetMaxU64(&offset, reg_info->byte_size);
+  }
+
+  if (offset == reg_info->byte_offset + reg_info->byte_size) {
+    if (reg_info->byte_size < sizeof(v))
+      value = (uint32_t)v;
+    else
+      value = v;
+    return true;
+  }
+}*/
   } else {
     uint64_t v = m_gpr.GetMaxU64(&offset, reg_info->byte_size);
 

--- a/lldb/source/Plugins/Process/aix-core/RegisterContextCoreAIX_ppc64.h
+++ b/lldb/source/Plugins/Process/aix-core/RegisterContextCoreAIX_ppc64.h
@@ -9,10 +9,10 @@
 #ifndef LLDB_SOURCE_PLUGINS_PROCESS_AIX_CORE_REGISTERCONTEXTAIXCORE_PPC64_H
 #define LLDB_SOURCE_PLUGINS_PROCESS_AIX_CORE_REGISTERCONTEXTAIXCORE_PPC64_H
 
-#include "Plugins/Process/Utility/RegisterContextPOSIX_ppc64le.h"
+#include "Plugins/Process/Utility/RegisterContextPOSIX_ppc64.h"
 #include "lldb/Utility/DataExtractor.h"
 
-class RegisterContextCoreAIX_ppc64 : public RegisterContextPOSIX_ppc64le {
+class RegisterContextCoreAIX_ppc64 : public RegisterContextPOSIX_ppc64 {
 public:
   RegisterContextCoreAIX_ppc64(
       lldb_private::Thread &thread,

--- a/lldb/source/Plugins/Process/aix-core/ThreadAIXCore.cpp
+++ b/lldb/source/Plugins/Process/aix-core/ThreadAIXCore.cpp
@@ -119,10 +119,8 @@ bool ThreadAIXCore::CalculateStopInfo() {
 
 void AIXSigInfo::Parse(const AIXCORE::AIXCore64Header data, const ArchSpec &arch,
                               const lldb_private::UnixSignals &unix_signals) {
-    Log *log = GetLog(LLDBLog::Process);
     si_signo = data.SignalNum;
     sigfault.si_addr = data.Fault.context.pc;
-    LLDB_LOG(log, "Parse pc {0}", data.Fault.context.pc);
 }
 
 void AIXSigInfo::Parse(const AIXCORE::AIXCore32Header data, const ArchSpec &arch,

--- a/lldb/source/Plugins/Process/aix-core/ThreadAIXCore.cpp
+++ b/lldb/source/Plugins/Process/aix-core/ThreadAIXCore.cpp
@@ -16,9 +16,7 @@
 #include "lldb/Utility/Log.h"
 #include "lldb/Utility/ProcessInfo.h"
 
-#include "Plugins/Process/Utility/RegisterContextPOSIX_powerpc.h"
-#include "Plugins/Process/Utility/RegisterContextPOSIX_ppc64le.h"
-#include "Plugins/Process/Utility/RegisterInfoPOSIX_ppc64le.h"
+#include "Plugins/Process/Utility/RegisterContextPOSIX_ppc64.h"
 #include "Plugins/Process/Utility/RegisterInfoPOSIX_ppc64.h"
 #include "Plugins/Process/elf-core/RegisterContextPOSIXCore_powerpc.h"
 #include "RegisterContextCoreAIX_ppc64.h"
@@ -121,8 +119,10 @@ bool ThreadAIXCore::CalculateStopInfo() {
 
 void AIXSigInfo::Parse(const AIXCORE::AIXCore64Header data, const ArchSpec &arch,
                               const lldb_private::UnixSignals &unix_signals) {
+    Log *log = GetLog(LLDBLog::Process);
     si_signo = data.SignalNum;
     sigfault.si_addr = data.Fault.context.pc;
+    LLDB_LOG(log, "Parse pc {0}", data.Fault.context.pc);
 }
 
 void AIXSigInfo::Parse(const AIXCORE::AIXCore32Header data, const ArchSpec &arch,


### PR DESCRIPTION
32-bit design change integration had missed coredump handling update, so it was seeing issues:
without fix:
```
# bin/lldb --core ../tests/core-64
(lldb) target create --core "../tests/core-64"
Core file '/home/dhruv/LLDB/tests/core-64' (powerpc64) was loaded.
(lldb) bt
* thread #1, name = 'coretest64', stop reason = SIGSEGV
  * frame #0: 0x00000001000004ac coretest64`__start + 116
(lldb) register read
General Purpose Registers:
        r0 = 0x000000010000048c  coretest64`__start + 84
        r1 = 0x0ffffffffffff770
        r2 = 0x0000000110000be8
        r3 = 0x000000000000006e
        r4 = 0x0000000100000964  coretest64`main + 68
        r5 = 0x0ffffffffffff7f0
        r6 = 0x800000000000d032
        r7 = 0x0fffffffffffffe0
        r8 = 0x0000000000000000
        r9 = 0xf10001007d572800
       r10 = 0x0000000000000000
       r11 = 0x0000000000001030
       r12 = 0xf10006000013ebc8
       r13 = 0x000000011000b000
       r14 = 0x0000000000000001
       r15 = 0x0ffffffffffff7e0
       r16 = 0x0ffffffffffff7f0
       r17 = 0x0800200140000000
       r18 = 0x0ffffffffffffed0
       r19 = 0x09fffffff00107b8  usla64`usl_exec_init_mods
       r20 = 0xbadc0ffee0ddf00d
       r21 = 0xbadc0ffee0ddf00d
       r22 = 0xbadc0ffee0ddf00d
       r23 = 0xbadc0ffee0ddf00d
       r24 = 0xbadc0ffee0ddf00d
       r25 = 0xbadc0ffee0ddf00d
       r26 = 0xbadc0ffee0ddf00d
       r27 = 0xbadc0ffee0ddf00d
       r28 = 0xbadc0ffee0ddf00d
       r29 = 0xbadc0ffee0ddf00d
       r30 = 0xbadc0ffee0ddf00d
       r31 = 0xbadc0ffee0ddf00d
        cr = 0x00000001
       msr = 0x800000000000d032
       xer = 0x00000940
        lr = 0x0000000000000000
       ctr = 0x0000000000000000
        pc = 0x00000001000004ac  coretest64`__start + 116
        f0 = 0
        f1 = 0
        f2 = 2.1219969791931506E-314

(lldb) q
```

with fix:
```
# bin/lldb --core ../tests/core-64
(lldb) target create --core "../tests/core-64"
m_is32 0
cpu_type 2
Core file '/home/dhruv/LLDB/tests/core-64' (powerpc64) was loaded.
(lldb) bt
* thread #1, name = 'coretest64', stop reason = SIGSEGV
  * frame #0: 0x0000000100000940 coretest64`main at core.c:5
    frame #1: 0x00000001000004ac coretest64`__start + 116
(lldb) re read 
General Purpose Registers:
        r0 = 0x000000010000048c  coretest64`__start + 84
        r1 = 0x0ffffffffffff770
        r2 = 0x0000000110000be8
        r3 = 0x000000000000006e
        r4 = 0x0000000100000964  coretest64`main + 68
        r5 = 0x0ffffffffffff7f0
        r6 = 0x800000000000d032
        r7 = 0x0fffffffffffffe0
        r8 = 0x0000000000000000
        r9 = 0xf10001007d572800
       r10 = 0x0000000000000000
       r11 = 0x0000000000001030
       r12 = 0xf10006000013ebc8
       r13 = 0x000000011000b000
       r14 = 0x0000000000000001
       r15 = 0x0ffffffffffff7e0
       r16 = 0x0ffffffffffff7f0
       r17 = 0x0800200140000000
       r18 = 0x0ffffffffffffed0
       r19 = 0x09fffffff00107b8  usla64`usl_exec_init_mods
       r20 = 0xbadc0ffee0ddf00d
       r21 = 0xbadc0ffee0ddf00d
       r22 = 0xbadc0ffee0ddf00d
       r23 = 0xbadc0ffee0ddf00d
       r24 = 0xbadc0ffee0ddf00d
       r25 = 0xbadc0ffee0ddf00d
       r26 = 0xbadc0ffee0ddf00d
       r27 = 0xbadc0ffee0ddf00d
       r28 = 0xbadc0ffee0ddf00d
       r29 = 0xbadc0ffee0ddf00d
       r30 = 0xbadc0ffee0ddf00d
       r31 = 0xbadc0ffee0ddf00d
        cr = 0x4272b228
       msr = 0x800000000000d032
       xer = 0x00000000
        lr = 0x00000001000004ac  coretest64`__start + 116
       ctr = 0x0000000000000000
        pc = 0x0000000100000940  coretest64`main + 32 at core.c:5

(lldb) q
```

Co-authored by: Hemang Gadhavi <hemang.gadhavi@ibm.com>

