### PR TITLE
Add fix for next issue with latest compiler

### DIFF
--- a/lldb/source/Plugins/Instruction/PPC64/EmulateInstructionPPC64.cpp
+++ b/lldb/source/Plugins/Instruction/PPC64/EmulateInstructionPPC64.cpp
@@ -789,6 +789,16 @@ bool EmulateInstructionPPC64::EmulateB(uint32_t opcode) {
   if (AA) {
     // Absolute addressing: NIA = sign_extend(LI || 0b00)
     next_pc = static_cast<uint64_t>(target_addr);
+
+    // if the absolute target address is a low memory address
+    // (< 0x10000000, typically millicode)
+    // skip the branch and continue to the next instruction instead.
+    if (next_pc < 0x10000000ULL) {
+      LLDB_LOG(log,
+               "EmulateB: Detected bla to low memory address {0:x}, "
+               "skipping to next instruction", next_pc);
+      next_pc = pc_value + 4;
+    }
   } else {
     // Relative addressing: NIA = CIA + sign_extend(LI || 0b00)
     next_pc = pc_value + target_addr;

--- a/lldb/source/Plugins/Instruction/PPC64/EmulateInstructionPPC64.cpp
+++ b/lldb/source/Plugins/Instruction/PPC64/EmulateInstructionPPC64.cpp
@@ -27,6 +27,9 @@
 
 #include "Plugins/Process/Utility/InstructionUtils.h"
 
+//  Define a low/reserved address range for AIX
+#define  LOWADDR         0x10000000ULL
+
 using namespace lldb;
 using namespace lldb_private;
 
@@ -793,7 +796,7 @@ bool EmulateInstructionPPC64::EmulateB(uint32_t opcode) {
     // if the absolute target address is a low memory address
     // (< 0x10000000, typically millicode)
     // skip the branch and continue to the next instruction instead.
-    if (next_pc < 0x10000000ULL) {
+    if (next_pc < LOWADDR) {
       LLDB_LOG(log,
                "EmulateB: Detected bla to low memory address {0:x}, "
                "skipping to next instruction", next_pc);


### PR DESCRIPTION
LLDB was not placing the breakpoint on the next instruction when executing the next command. This issue is only reproducible with the latest compiler, as recent compiler changes have modified the generated instruction sequence.
Added the macro to validate the lower address range. 

Old Compiler:
----------
```
    0x10000764 <+36>:  stw    3, 64(31)
    0x10000768 <+40>:  li     4, 65
    0x1000076c <+44>:  li     5, 512
->  0x10000770 <+48>:  bl     0x100007e0                ; symbol stub for: memset
    0x10000774 <+52>:  nop    
    0x10000778 <+56>:  lwz    3, 64(31)
    0x1000077c <+60>:  lwz    4, 96(2)
    0x10000780 <+64>:  bl     0x100007fc                ; symbol stub for: strcpy
```

New Compiler:
-----------
```
    0x10000764 <+36>:  stw    3, 64(31)
    0x10000768 <+40>:  li     4, 65
    0x1000076c <+44>:  li     5, 512
->  0x10000770 <+48>:  bla    0xe008
    0x10000774 <+52>:  nop    
    0x10000778 <+56>:  lwz    3, 64(31)
    0x1000077c <+60>:  lwz    4, 96(2)
    0x10000780 <+64>:  bl     0x100007c8                ; symbol stub for: strcpy
```



Without fix :
------------
```
# lldb iss_175        
Unable to open log file '/home/LLDB2.0/lldb-init-file': No such file or directory
(lldb) target create "iss_175"
Current executable set to '/LLDB/hemang/testcase/32_defets/iss_175' (powerpc).
(lldb) b main
Breakpoint 1: where = iss_175`main + 48 at iss_175.c:6, address = 0x10000770
(lldb) r
Process 28311854 launched: '/LLDB/hemang/testcase/32_defets/iss_175' (powerpc)
Process 28311854 stopped
* thread #1, name = 'iss_175', stop reason = breakpoint 1.1
      frame #0: 0x10000770 iss_175`main at iss_175.c:6
   3     
   4     int main() {
   5         char buffer[512];
-> 6         memset(buffer, 'A', 512);
   7         strcpy(buffer, "This is a test message in the buffer");
   8         printf("Buffer address: %p\n", buffer);
   9         return 0;
(lldb) n
Buffer address: 2ff226b8
Process 28311854 exited with status = 0 (0x00000000) 
```

with fix:
---------
```
# lldb iss_175
Unable to open log file '/home/LLDB2.0/lldb-init-file': No such file or directory
(lldb) target create "iss_175"
Current executable set to '/LLDB/hemang/testcase/32_defets/iss_175' (powerpc).
(lldb) b main
Breakpoint 1: where = iss_175`main + 48 at iss_175.c:6, address = 0x10000770
(lldb) r
Process 30605754 launched: '/LLDB/hemang/testcase/32_defets/iss_175' (powerpc)
Process 30605754 stopped
* thread #1, name = 'iss_175', stop reason = breakpoint 1.1
      frame #0: 0x10000770 iss_175`main at iss_175.c:6
   3     
   4     int main() {
   5         char buffer[512];
-> 6         memset(buffer, 'A', 512);
   7         strcpy(buffer, "This is a test message in the buffer");
   8         printf("Buffer address: %p\n", buffer);
   9         return 0;
(lldb) n
Process 30605754 stopped
* thread #1, name = 'iss_175', stop reason = step over
      frame #0: 0x10000778 iss_175`main at iss_175.c:7
   4     int main() {
   5         char buffer[512];
   6         memset(buffer, 'A', 512);
-> 7         strcpy(buffer, "This is a test message in the buffer");
   8         printf("Buffer address: %p\n", buffer);
   9         return 0;
   10    }
(lldb) n
Process 30605754 stopped
* thread #1, name = 'iss_175', stop reason = step over
      frame #0: 0x1000078c iss_175`main at iss_175.c:8
   5         char buffer[512];
   6         memset(buffer, 'A', 512);
   7         strcpy(buffer, "This is a test message in the buffer");
-> 8         printf("Buffer address: %p\n", buffer);
   9         return 0;
   10    }
```
