### PR TITLE
Add fix for global var access issue with latest compiler

### DIFF
--- a/lldb/source/Plugins/DynamicLoader/AIX-DYLD/DynamicLoaderAIXDYLD.cpp
+++ b/lldb/source/Plugins/DynamicLoader/AIX-DYLD/DynamicLoaderAIXDYLD.cpp
@@ -420,6 +420,8 @@ void DynamicLoaderAIXDYLD::DidAttach() {
         // FIXME: .tdata, .bss
       }
     } else {
+      // First entry is the main executable - update data section with runtime address
+      UpdateLoadedSectionsByType(executable, LLDB_INVALID_ADDRESS, (lldb::addr_t)ptr->ldinfo_dataorg, false, 2);
       skip_current = false;
     }
     if (ptr->ldinfo_next == 0) {
@@ -481,6 +483,8 @@ void DynamicLoaderAIXDYLD::DidLaunch() {
         // FIXME: .tdata, .bss
       }
     } else {
+      // First entry is the main executable - update data section with runtime address
+      UpdateLoadedSectionsByType(executable, LLDB_INVALID_ADDRESS, (lldb::addr_t)ptr->ldinfo_dataorg, false, 2);
       skip_current = false;
     }
     if (ptr->ldinfo_next == 0) {

--- a/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.cpp
+++ b/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.cpp
@@ -239,14 +239,30 @@ bool ObjectFileXCOFF::SetLoadAddressByType(Target &target, lldb::addr_t value,
         SectionSP section_sp(section_list->GetSectionAtIndex(sect_idx));
         if (type_id == 1 && section_sp && strcmp(section_sp->GetName().AsCString(nullptr), ".text") == 0) {
           if (!section_sp->IsThreadSpecific()) {
+            // - If value_is_offset is true: add value to file offset
+            // - If value_is_offset is false: value is the absolute runtime address
+            lldb::addr_t load_addr;
+            if (value_is_offset) {
+              load_addr = section_sp->GetFileOffset() + value;
+            } else {
+              load_addr = value;
+            }
             if (target.GetSectionLoadListPublic().SetSectionLoadAddress(
-                    section_sp, section_sp->GetFileOffset() + value))
+                    section_sp, load_addr))
               ++num_loaded_sections;
           }
         } else if (type_id == 2 && section_sp && strcmp(section_sp->GetName().AsCString(nullptr), ".data") == 0) {
           if (!section_sp->IsThreadSpecific()) {
+            // - If value_is_offset is true: add value to file address
+            // - If value_is_offset is false: value is the absolute runtime address
+            lldb::addr_t load_addr;
+            if (value_is_offset) {
+              load_addr = section_sp->GetFileAddress() + value;
+            } else {
+              load_addr = value;
+            }
             if (target.GetSectionLoadListPublic().SetSectionLoadAddress(
-                    section_sp, section_sp->GetFileAddress() + value))
+                    section_sp, load_addr))
               ++num_loaded_sections;
           }
         }


### PR DESCRIPTION
Add a fix to resolve global, static and namespace variables with latest compiler.


Without Fix:
-----------

```
(lldb) n
Address countVar: 20019d28
Process 21037550 stopped
* thread #1, name = 'cpp_iss', stop reason = step over
      frame #0: 0x100007bc cpp_iss`main at cpp_iss.cpp:10
   7     int main() {
   8         cout << "countVar: " << countVar << endl;
   9         cout << "Address countVar: " << &countVar << endl;
-> 10        return countVar;
   11    }
(lldb) p countVar
(int) 1950709872
(lldb) p &countVar
(int *) 0x20000d28
(lldb)  target module dump section cpp_iss
Sections for '/LLDB/hemang/testcase/32_defets/cpp_iss' (powerpc):
  SectID             Type                   Load Address                             Perm File Off.  File Size  Flags      Section Name
  ------------------ ---------------------- ---------------------------------------  ---- ---------- ---------- ---------- ----------------------------
  0x0000000000000001 code                   [0x0000000010000268-0x0000000010002b8c)  r-x  0x00000268 0x00002924 0x00000020 cpp_iss..text
  0x0000000000000002 data                   [0x0000000020000b8c-0x0000000020000e7c)  rw-  0x00002b8c 0x000002f0 0x00000040 cpp_iss..data
  0x0000000000000003 zero-fill              [0x0000000020000e7c-0x0000000020000e8c)  rw-  0x00000000 0x00000010 0x00000080 cpp_iss..bss
  0x0000000000000004 regular                [0x0000000000000000-0x0000000000000ade)  r--  0x00002e7c 0x00000ade 0x00001000 cpp_iss..loader
  0x0000000000000005 dwarf-line             [0x0000000000000000-0x0000000000000728)  r--  0x0000395a 0x00000728 0x00020010 cpp_iss..dwline
  0x0000000000000006 dwarf-info             [0x0000000000000000-0x000000000000d893)  r--  0x00004082 0x0000d893 0x00010010 cpp_iss..dwinfo
  0x0000000000000007 dwarf-abbrev           [0x0000000000000000-0x000000000000053b)  r--  0x00011916 0x0000053b 0x00060010 cpp_iss..dwabrev
  0x0000000000000008 dwarf-ranges           [0x0000000000000000-0x0000000000000058)  r--  0x00011e52 0x00000058 0x00080010 cpp_iss..dwrnges

```


with Fix :
-------------

```
(lldb) n
Address countVar: 20019d28
Process 22348230 stopped
* thread #1, name = 'cpp_iss', stop reason = step over
      frame #0: 0x100007bc cpp_iss`main at cpp_iss.cpp:10
   7     int main() {
   8         cout << "countVar: " << countVar << endl;
   9         cout << "Address countVar: " << &countVar << endl;
-> 10        return countVar;
   11    }
(lldb) p countVar
(int) 10
(lldb) p &countVar
(int *) 0x20019d28
(lldb) target module dump section cpp_iss
Sections for '/LLDB/hemang/testcase/32_defets/cpp_iss' (powerpc):
  SectID             Type                   Load Address                             Perm File Off.  File Size  Flags      Section Name
  ------------------ ---------------------- ---------------------------------------  ---- ---------- ---------- ---------- ----------------------------
  0x0000000000000001 code                   [0x0000000010000268-0x0000000010002b8c)  r-x  0x00000268 0x00002924 0x00000020 cpp_iss..text
  0x0000000000000002 data                   [0x0000000020019b8c-0x0000000020019e7c)  rw-  0x00002b8c 0x000002f0 0x00000040 cpp_iss..data
  0x0000000000000003 zero-fill              [0x0000000020000e7c-0x0000000020000e8c)  rw-  0x00000000 0x00000010 0x00000080 cpp_iss..bss
  0x0000000000000004 regular                [0x0000000000000000-0x0000000000000ade)  r--  0x00002e7c 0x00000ade 0x00001000 cpp_iss..loader
  0x0000000000000005 dwarf-line             [0x0000000000000000-0x0000000000000728)  r--  0x0000395a 0x00000728 0x00020010 cpp_iss..dwline
  0x0000000000000006 dwarf-info             [0x0000000000000000-0x000000000000d893)  r--  0x00004082 0x0000d893 0x00010010 cpp_iss..dwinfo
  0x0000000000000007 dwarf-abbrev           [0x0000000000000000-0x000000000000053b)  r--  0x00011916 0x0000053b 0x00060010 cpp_iss..dwabrev
  0x0000000000000008 dwarf-ranges           [0x0000000000000000-0x0000000000000058)  r--  0x00011e52 0x00000058 0x00080010 cpp_iss..dwrnges
(lldb) 
```