### PR TITLE
Fix for Redundant entries of libraries on re-run

### DIFF
--- a/lldb/source/Plugins/DynamicLoader/AIX-DYLD/DynamicLoaderAIXDYLD.cpp
+++ b/lldb/source/Plugins/DynamicLoader/AIX-DYLD/DynamicLoaderAIXDYLD.cpp
@@ -442,7 +442,6 @@ void DynamicLoaderAIXDYLD::DidLaunch() {
   // were cleared), try to resolve it again
   if (!executable.get()) {
     ResolveExecutableModule(executable);
-    executable = GetTargetExecutable();
     if (!executable.get()) {
       LLDB_LOG(log, "failed to get target executable module");
       return;

--- a/lldb/source/Plugins/DynamicLoader/AIX-DYLD/DynamicLoaderAIXDYLD.cpp
+++ b/lldb/source/Plugins/DynamicLoader/AIX-DYLD/DynamicLoaderAIXDYLD.cpp
@@ -438,8 +438,16 @@ void DynamicLoaderAIXDYLD::DidLaunch() {
   LLDB_LOGF(log, "DynamicLoaderAIXDYLD::%s()", __FUNCTION__);
 
   ModuleSP executable = GetTargetExecutable();
-  if (!executable.get())
-    return;
+  // If executable is not available (e.g., after process rerun when modules
+  // were cleared), try to resolve it again
+  if (!executable.get()) {
+    ResolveExecutableModule(executable);
+    executable = GetTargetExecutable();
+    if (!executable.get()) {
+      LLDB_LOG(log, "failed to get target executable module");
+      return;
+    }
+  }
 
   lldb::addr_t load_addr = GetLoadAddress(executable);
   if (load_addr != LLDB_INVALID_ADDRESS) {

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -307,6 +307,13 @@ void Target::DeleteCurrentProcess() {
     // the section load history that can mess up subsequent processes.
     m_section_load_history.Clear();
 
+#if defined(_AIX)
+    // On AIX, clear the loaded image list when the process is destroyed.
+    // This ensures that a subsequent rerun reloads the current set of
+    // modules and prevents stale image entries from previous runs
+    m_images.Clear();
+#endif
+
     CleanupProcess();
 
     m_process_sp.reset();


### PR DESCRIPTION
Without Fix:
------------
```
(lldb) image list
[  0]                                      0x10000268 /LLDB/hemang/testcase/32_defets/sleep_atch 
[  1]                                      0xd0652000 /usr/lib/libpthreads.a (shr_comm.o)
[  2]                                      0xd0616000 /usr/lib/libpthreads.a (_shr_xpg5.o)
[  3]                                      0xd0615100 /usr/lib/libcrypt.a (shr.o)
[  4]                                      0xd019c180 /usr/lib/libc.a (_shr.o)
[  5]                                      0xd0193000 /usr/lib/libpthreads.a (shr_xpg5.o)
[  6]                                      0xd0100000 /usr/lib/libc.a (shr.o)
(lldb) r
There is a running process, kill it and restart?: [Y/n] y
Process 21102926 exited with status = 9 (0x00000009) killed
Process 21102928 launched: '/LLDB/hemang/testcase/32_defets/sleep_atch' (powerpc)
Process 21102928 stopped
* thread #1, name = 'sleep_atch', stop reason = breakpoint 1.1
      frame #0: 0x10000810 sleep_atch`main at sleep_atch.c:16
   13    }                                                                               
   14                                                                                    
   15    int main() {                                                                    
-> 16        printf("Process started. PID: %d\n", getpid());                             
   17        printf("Waiting for LLDB to attach...\n");                                  
   18        fflush(stdout);                                                             
   19                                                                                    
(lldb) image list
[  0]                                      0x10000268 /LLDB/hemang/testcase/32_defets/sleep_atch 
[  1]                                      0xd0652000 /usr/lib/libpthreads.a (shr_comm.o)
[  2]                                      0xd0616000 /usr/lib/libpthreads.a (_shr_xpg5.o)
[  3]                                      0xd0615100 /usr/lib/libcrypt.a (shr.o)
[  4]                                      0xd019c180 /usr/lib/libc.a (_shr.o)
[  5]                                      0xd0193000 /usr/lib/libpthreads.a (shr_xpg5.o)
[  6]                                      0xd0100000 /usr/lib/libc.a (shr.o)
[  7]                                      0xd0652000 /usr/lib/libpthreads.a (shr_comm.o)
[  8]                                      0xd0616000 /usr/lib/libpthreads.a (_shr_xpg5.o)
[  9]                                      0xd0615100 /usr/lib/libcrypt.a (shr.o)
[ 10]                                      0xd019c180 /usr/lib/libc.a (_shr.o)
[ 11]                                      0xd0193000 /usr/lib/libpthreads.a (shr_xpg5.o)
[ 12]                                      0xd0100000 /usr/lib/libc.a (shr.o)
```


With Fix:
----------
```
(lldb) image list
[  0]                                      0x10000268 /LLDB/hemang/testcase/32_defets/sleep_atch 
[  1]                                      0xd0652000 /usr/lib/libpthreads.a (shr_comm.o)
[  2]                                      0xd0616000 /usr/lib/libpthreads.a (_shr_xpg5.o)
[  3]                                      0xd0615100 /usr/lib/libcrypt.a (shr.o)
[  4]                                      0xd019c180 /usr/lib/libc.a (_shr.o)
[  5]                                      0xd0193000 /usr/lib/libpthreads.a (shr_xpg5.o)
[  6]                                      0xd0100000 /usr/lib/libc.a (shr.o)
(lldb) r
There is a running process, kill it and restart?: [Y/n] y
Process 23331200 exited with status = 9 (0x00000009) killed
Process 20971854 launched: '/LLDB/hemang/testcase/32_defets/sleep_atch' (powerpc)
Process 20971854 stopped
* thread #1, name = 'sleep_atch', stop reason = breakpoint 1.1
      frame #0: 0x10000810 sleep_atch`main at sleep_atch.c:16
   13    }                                                                               
   14                                                                                    
   15    int main() {                                                                    
-> 16        printf("Process started. PID: %d\n", getpid());                             
   17        printf("Waiting for LLDB to attach...\n");                                  
   18        fflush(stdout);                                                             
   19                                                                                    
(lldb) image list
[  0]                                      0x10000268 /LLDB/hemang/testcase/32_defets/sleep_atch 
[  1]                                      0xd0652000 /usr/lib/libpthreads.a (shr_comm.o)
[  2]                                      0xd0616000 /usr/lib/libpthreads.a (_shr_xpg5.o)
[  3]                                      0xd0615100 /usr/lib/libcrypt.a (shr.o)
[  4]                                      0xd019c180 /usr/lib/libc.a (_shr.o)
[  5]                                      0xd0193000 /usr/lib/libpthreads.a (shr_xpg5.o)
[  6]                                      0xd0100000 /usr/lib/libc.a (shr.o)
```
