### PR TITLE
Fix for core stack not displaying for 32&64 for 22.1.2.4

### DIFF
--- a/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.cpp
+++ b/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.cpp
@@ -239,16 +239,8 @@ bool ObjectFileXCOFF::SetLoadAddressByType(Target &target, lldb::addr_t value,
         SectionSP section_sp(section_list->GetSectionAtIndex(sect_idx));
         if (type_id == 1 && section_sp && strcmp(section_sp->GetName().AsCString(nullptr), ".text") == 0) {
           if (!section_sp->IsThreadSpecific()) {
-            // - If value_is_offset is true: add value to file offset
-            // - If value_is_offset is false: value is the absolute runtime address
-            lldb::addr_t load_addr;
-            if (value_is_offset) {
-              load_addr = section_sp->GetFileOffset() + value;
-            } else {
-              load_addr = value;
-            }
             if (target.GetSectionLoadListPublic().SetSectionLoadAddress(
-                    section_sp, load_addr))
+                    section_sp, section_sp->GetFileOffset() + value))
               ++num_loaded_sections;
           }
         } else if (type_id == 2 && section_sp && strcmp(section_sp->GetName().AsCString(nullptr), ".data") == 0) {


### PR DESCRIPTION
without fix:
---------------
```
# lldb
Unable to open log file '/home/LLDB2.0/lldb-init-file': No such file or directory
(lldb)  target create --core "core"                                                                                                                                                           
Core file '/LLDB/hemang/testcase/core' (powerpc64) was loaded.
(lldb) bt
* thread #1, name = 'core_test', stop reason = SIGSEGV
  * frame #0: 0x0000000100000938 core_test`
```
  
  with fix:
-----------
```
  # lldb -c core
Unable to open log file '/home/LLDB2.0/lldb-init-file': No such file or directory
(lldb) target create --core "core"
Core file '/LLDB/hemang/testcase/core' (powerpc64) was loaded.
(lldb) bt
* thread #1, name = 'core_test', stop reason = SIGSEGV
  * frame #0: 0x0000000100000938 core_test`main at core.c:6
    frame #1: 0x00000001000004ac core_test`__start + 116
```

