### PR TITLE
Add fix for SAP attach iss

### DIFF
--- a/lldb/source/Host/aix/Host.cpp
+++ b/lldb/source/Host/aix/Host.cpp
@@ -179,8 +179,10 @@ static bool GetExePathAndIds(::pid_t pid, ProcessInstanceInfo &process_info) {
   if (PathRef.empty())
     return false;
 
+  llvm::StringRef executable = PathRef.split(' ').first;
+
   // Resolve the executable path to an absolute path
-  std::string resolved_path = ResolveExecutablePath(PathRef, pid);
+  std::string resolved_path = ResolveExecutablePath(executable, pid);
   process_info.GetExecutableFile().SetFile(resolved_path,
                                            FileSpec::Style::native);
   ArchSpec arch_spec = GetXCOFFProcessCPUType(resolved_path);


### PR DESCRIPTION
With fix

```
# ps 
 32244216  pts/2  0:01 disp+work pf=HDA_ASCS01_is3068
 
 
(lldb) process attach --pid 32244216
error: disp+work [0x000000002bf6d410]: invalid abbreviation code 400, please file a bug and attach the file at the start of this error message
error: disp+work [0x000000002bf6c369]: invalid abbreviation code 120, please file a bug and attach the file at the start of this error message
error: disp+work [0x000000002bfb8d3f]: invalid abbreviation code 940, please file a bug and attach the file at the start of this error message
error: libregexpcre2.so [0x000000000002314a]: invalid abbreviation code 49210, please file a bug and attach the file at the start of this error message
error: libregexpcre2.so [0x0000000000023231]: invalid abbreviation code 14, please file a bug and attach the file at the start of this error message
error: libregexpcre2.so [0x0000000000020aa3]: invalid abbreviation code 1579, please file a bug and attach the file at the start of this error message
Process 32244216 stopped
* thread #1, name = 'disp+work', stop reason = signal SIGSTOP
      frame #0: 0x09000000002e2acc libc.a`read_real_time + 12
libc.a`read_real_time:
->  0x9000000002e2acc <+12>: mfspr  5, 268
    0x9000000002e2ad0 <+16>: stw    4, 0(3)
    0x9000000002e2ad4 <+20>: addc   5, 5, 7
    0x9000000002e2ad8 <+24>: ld     11, 48(2)
Executable binary set to "disp+work".
Architecture set to: powerpc64-ibm-aix7.3.0.0.
(lldb) bt
* thread #1, name = 'disp+work', stop reason = signal SIGSTOP
  * frame #0: 0x09000000002e2acc libc.a`read_real_time + 12
    frame #1: 0x0900000000397c44 libc.a`gettimeofday + 964
    frame #2: 0x00000001003e9b54 disp+work`delay_usec(tusec_delay=150000) at pfclock.c:984
    frame #3: 0x00000001003e959c disp+work`adjust_clock() at pfclock.c:893
    frame #4: 0x00000001003e946c disp+work`pfinit_clock(clks_per_mu10=0x0ffffffffffff38c, clk_null_time10=0x0ffffffffffff388) at pfclock.c:688
    frame #5: 0x000000010e020dd0 disp+work`DpSapEnvInit(DPTIMESTAMP) + 48
    frame #6: 0x00000001000160ac disp+work`DpMain + 3052
    frame #7: 0x000000010001546c disp+work`nlsui_main + 44
    frame #8: 0x0000000100000a08 disp+work`main at thxxanf.c:61
    frame #9: 0x000000010000053c disp+work`__start + 116
(lldb) q
```