### PR TITLE
Watchpoint assertion defect

### DIFF
--- a/lldb/source/Commands/CommandObjectWatchpoint.cpp
+++ b/lldb/source/Commands/CommandObjectWatchpoint.cpp
@@ -1072,9 +1072,9 @@ protected:
       } else {
           size = target->GetArchitecture().GetAddressByteSize();
           result.AppendWarning(
-              "Cannot infer watchpoint size from expression. "
-              "Defaulting to pointer size. \n"
-              "Use -s option to specify size explicitly.");
+              "Cannot infer watchpoint size from expression.\n"
+              "Defaulting to pointer size.\n"
+              "Use -s option to specify size explicitly");
       }
 #endif
     }


### PR DESCRIPTION
Fixes: 
- #184 

```
With
(lldb) n
Process 20709778 stopped
* thread #1, name = '1200526', stop reason = step over
      frame #0: 0x000000010000094c 1200526`main at 1200526.c:5
   2    #include <stdlib.h>
   3    int main() {
   4      int *heap_var = (int*)malloc(sizeof(int));
-> 5      *heap_var = 50;
   6      printf("*heap_var=%d\\n", *heap_var);
   7      *heap_var = 100;
   8      printf("*heap_var=%d\\n", *heap_var);
(lldb) watch set expression *heap_var
warning: Cannot infer watchpoint size from expression. Defaulting to pointer size. 
Use -s option to specify size explicitly
error: Watchpoint creation failed (addr=0x0, size=8)
error: Setting one of the watchpoint resources failed
(lldb) q
```