### PR TITLE
Removes un-needed label symbols and hidden entries from the symbol

### DIFF
--- a/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.cpp
+++ b/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.cpp
@@ -315,6 +315,7 @@ void ObjectFileXCOFF::ParseSymtab(Symtab &lldb_symtab) {
     llvm::StringRef name_no_dot =
         symbolName.starts_with(".") ? symbolName.drop_front() : symbolName;
     auto storageClass = xcoff_sym_ref.getStorageClass();
+
     // C_HIDEXT symbols are not needed to be exposed, with the exception of TOC
     // which is responsible for storing references to global data
     if (storageClass == XCOFF::C_HIDEXT && symbolName != "TOC") {
@@ -343,6 +344,14 @@ void ObjectFileXCOFF::ParseSymtab(Symtab &lldb_symtab) {
       if (m_binary->is64Bit())
         if (csect_aux.getAuxType64() != XCOFF::AUX_CSECT)
           continue;
+
+      // XTY_LD symbols are label definitions that live inside another csect
+      // Unnamed XTY_SD XMC_PR csects are raw code bodies whose named entry
+      // point is a C_EXT XTY_LD symbol 
+      if ((csect_aux.getSymbolType() == XCOFF::XTY_LD) || 
+          (csect_aux.getSymbolType() == XCOFF::XTY_SD && symbolName.empty())) {
+        continue;
+      }
     }
 
     Symbol symbol;
@@ -378,6 +387,43 @@ void ObjectFileXCOFF::ParseSymtab(Symtab &lldb_symtab) {
 
     symbol.SetType(MapSymbolType(sym_type_or_err.get()));
 
+    // For other csect symbols (C_EXT, C_WEAKEXT, C_HIDEXT) use the csect auxiliary
+    // entry to determine the symbol's byte size and whether to keep it.
+    if (xcoff_sym_ref.isCsectSymbol()) {
+      auto aux_csect_or_err = xcoff_sym_ref.getXCOFFCsectAuxRef();
+      if (aux_csect_or_err) {
+        const llvm::object::XCOFFCsectAuxRef csect_aux = aux_csect_or_err.get();
+
+        if (csect_aux.getSymbolType() == XCOFF::XTY_SD) {
+          XCOFF::StorageMappingClass smc = csect_aux.getStorageMappingClass();
+
+          // XMC_DS is a function descriptor csect in .data (3 pointers)
+          // Skip it as it is not code and would shadow the real entry symbol
+          if (smc == XCOFF::XMC_DS) {
+            continue;
+          }
+
+          // XMC_RO, XMC_RW, and XMC_BS are non-code csects (read-only data
+          // tables, writable data, BSS)
+          if (smc == XCOFF::XMC_RO || smc == XCOFF::XMC_RW ||
+              smc == XCOFF::XMC_BS) {
+            symbol.GetAddressRef() = Address();
+            uint64_t csect_size = csect_aux.getSectionOrLength();
+            if (csect_size > 0)
+              symbol.SetByteSize(csect_size);
+          } else if (smc == XCOFF::XMC_PR) {
+            // XMC_PR is a standalone named code csect (not an entry label
+            // inside a larger csect).  Set its declared size directly.
+            uint64_t csect_size = csect_aux.getSectionOrLength();
+            if (csect_size > 0) {
+              symbol.SetByteSize(csect_size);
+            }
+          }
+        }
+      } else {
+        llvm::consumeError(aux_csect_or_err.takeError());
+      }
+    }
     lldb_symtab.AddSymbol(symbol);
   }
 }

--- a/lldb/source/Plugins/Process/aix-core/ProcessAIXCore.cpp
+++ b/lldb/source/Plugins/Process/aix-core/ProcessAIXCore.cpp
@@ -21,6 +21,7 @@
 #include "lldb/Target/Target.h"
 #include "lldb/Target/UnixSignals.h"
 #include "lldb/Utility/DataBufferHeap.h"
+#include "lldb/Utility/Flags.h"
 #include "lldb/Utility/LLDBLog.h"
 #include "lldb/Utility/Log.h"
 #include "lldb/Utility/State.h"
@@ -107,11 +108,16 @@ ProcessAIXCore::~ProcessAIXCore() {
 }
 
 lldb::addr_t ProcessAIXCore::AddAddressRanges(AIXCORE::AIXCore64Header header) {
-  const lldb::addr_t addr = header.StackBaseAddr;
-  FileRange file_range(header.StackOffset, header.StackSize);
-  VMRangeToFileOffset::Entry range_entry(addr, header.StackSize, file_range);
+  const uint32_t rw = lldb::ePermissionsReadable | lldb::ePermissionsWritable;
 
-  if (header.StackSize > 0) {
+  // Helper lambda: append one (vm_addr, file_offset, size) region to both
+  // address range tables, merging with the previous entry when contiguous.
+  auto append = [&](lldb::addr_t vm_addr, lldb::addr_t file_offset,
+                    lldb::addr_t size, uint32_t permissions) {
+    if (size == 0 || vm_addr == LLDB_INVALID_ADDRESS)
+      return;
+    FileRange file_range(file_offset, size);
+    VMRangeToFileOffset::Entry range_entry(vm_addr, size, file_range);
     VMRangeToFileOffset::Entry *last_entry = m_core_aranges.Back();
     if (last_entry &&
         last_entry->GetRangeEnd() == range_entry.GetRangeBase() &&
@@ -122,22 +128,32 @@ lldb::addr_t ProcessAIXCore::AddAddressRanges(AIXCORE::AIXCore64Header header) {
     } else {
         m_core_aranges.Append(range_entry);
     }
-  }
+    m_core_range_infos.Append(
+        VMRangeToPermissions::Entry(vm_addr, size, permissions));
+  };
 
-  const uint32_t permissions = lldb::ePermissionsReadable |
-      lldb::ePermissionsWritable;
+  // Stack region
+  append(header.StackBaseAddr, header.StackOffset, header.StackSize, rw);
 
-  m_core_range_infos.Append(
-      VMRangeToPermissions::Entry(addr, header.StackSize, permissions));
+  // Data region (.data)
+  append(header.DataBaseAddr, header.DataRegionOffset, header.DataSize, rw);
 
-  return addr;
+  // Small-data region (.sdata)
+  append(header.SDataBase, header.DataRegionOffset + header.DataSize,
+         header.SDataSize, rw);
+
+  return header.StackBaseAddr;
 }
-lldb::addr_t ProcessAIXCore::AddAddressRanges(AIXCORE::AIXCore32Header header) {
-  const lldb::addr_t addr = header.StackBaseAddr;
-  FileRange file_range(header.StackOffset, header.StackSize);
-  VMRangeToFileOffset::Entry range_entry(addr, header.StackSize, file_range);
 
-  if (header.StackSize > 0) {
+lldb::addr_t ProcessAIXCore::AddAddressRanges(AIXCORE::AIXCore32Header header) {
+  const uint32_t rw = lldb::ePermissionsReadable | lldb::ePermissionsWritable;
+
+  auto append = [&](lldb::addr_t vm_addr, lldb::addr_t file_offset,
+                    lldb::addr_t size, uint32_t permissions) {
+    if (size == 0 || vm_addr == LLDB_INVALID_ADDRESS)
+      return;
+    FileRange file_range(file_offset, size);
+    VMRangeToFileOffset::Entry range_entry(vm_addr, size, file_range);
     VMRangeToFileOffset::Entry *last_entry = m_core_aranges.Back();
     if (last_entry &&
         last_entry->GetRangeEnd() == range_entry.GetRangeBase() &&
@@ -148,15 +164,21 @@ lldb::addr_t ProcessAIXCore::AddAddressRanges(AIXCORE::AIXCore32Header header) {
     } else {
         m_core_aranges.Append(range_entry);
     }
-  }
+    m_core_range_infos.Append(
+        VMRangeToPermissions::Entry(vm_addr, size, permissions));
+  };
 
-  const uint32_t permissions = lldb::ePermissionsReadable |
-      lldb::ePermissionsWritable;
+  // Stack region
+  append(header.StackBaseAddr, header.StackOffset, header.StackSize, rw);
 
-  m_core_range_infos.Append(
-      VMRangeToPermissions::Entry(addr, header.StackSize, permissions));
+  // Data region (.data)
+  append(header.DataBaseAddr, header.DataRegionOffset, header.DataSize, rw);
 
-  return addr;
+  // Small-data region (.sdata)
+  append(header.SDataBase, header.DataRegionOffset + header.DataSize,
+         header.SDataSize, rw);
+
+  return header.StackBaseAddr;
 }
 
 bool ProcessAIXCore::CanDebug(lldb::TargetSP target_sp,
@@ -351,6 +373,9 @@ Status ProcessAIXCore::DoLoadCore() {
         return error;
     }
 
+    m_core_aranges.Sort();
+    m_core_range_infos.Sort();
+
     m_thread_data_valid = true;
     if (m_is64bit)
         ParseAIXCoreFile();
@@ -463,7 +488,42 @@ size_t ProcessAIXCore::DoReadMemory(lldb::addr_t addr, void *buf, size_t size,
 
 Status ProcessAIXCore::DoGetMemoryRegionInfo(lldb::addr_t load_addr,
                                               MemoryRegionInfo &region_info) {
+  region_info.Clear();
+  const VMRangeToPermissions::Entry *permission_entry =
+      m_core_range_infos.FindEntryThatContainsOrFollows(load_addr);
+  if (permission_entry) {
+    if (permission_entry->Contains(load_addr)) {
+      region_info.GetRange().SetRangeBase(permission_entry->GetRangeBase());
+      region_info.GetRange().SetRangeEnd(permission_entry->GetRangeEnd());
+      const Flags permissions(permission_entry->data);
+      region_info.SetReadable(permissions.Test(lldb::ePermissionsReadable)
+                                  ? eLazyBoolYes
+                                  : eLazyBoolNo);
+      region_info.SetWritable(permissions.Test(lldb::ePermissionsWritable)
+                                  ? eLazyBoolYes
+                                  : eLazyBoolNo);
+      region_info.SetExecutable(permissions.Test(lldb::ePermissionsExecutable)
+                                    ? eLazyBoolYes
+                                    : eLazyBoolNo);
+      region_info.SetMapped(eLazyBoolYes);
+    } else if (load_addr < permission_entry->GetRangeBase()) {
+      region_info.GetRange().SetRangeBase(load_addr);
+      region_info.GetRange().SetRangeEnd(permission_entry->GetRangeBase());
+      region_info.SetReadable(eLazyBoolNo);
+      region_info.SetWritable(eLazyBoolNo);
+      region_info.SetExecutable(eLazyBoolNo);
+      region_info.SetMapped(eLazyBoolNo);
+    }
     return Status();
+  }
+  // Address is beyond all known regions.
+  region_info.GetRange().SetRangeBase(load_addr);
+  region_info.GetRange().SetRangeEnd(LLDB_INVALID_ADDRESS);
+  region_info.SetReadable(eLazyBoolNo);
+  region_info.SetWritable(eLazyBoolNo);
+  region_info.SetExecutable(eLazyBoolNo);
+  region_info.SetMapped(eLazyBoolNo);
+  return Status();
 }
 
 Status ProcessAIXCore::DoDestroy() { return Status(); }


### PR DESCRIPTION
Removes un-needed label symbols and hidden entries from the symbol 
table saved in lldb to avoid symbol namespace pollution. 

Additionally, adds more accessibility to aix core to be able to read multiple memory regions (data, sdata).
Corrects the address range of alot of internal symbols such as `_doprnt`, `_doscan` etc

Before fix:
Live:
```
Process 24052192 stopped
* thread #1, name = 'a.out', stop reason = signal SIGSEGV
      frame #0: 0x000000000000ee00
->  0xee00: lbz    8, 0(3)
    0xee04: rldicr 10, 3, 0, 61
    0xee08: mr     11, 3
    0xee0c: lis    5, -258
(lldb) bt
* thread #1, name = 'a.out', stop reason = signal SIGSEGV
  * frame #0: 0x000000000000ee00
    frame #1: 0x090000000023b254 libc.a`BIN2DPDx + 1004
(lldb)
```
Coredump:
```
* thread #1, name = 'a.out', stop reason = signal SIGSEGV
      frame #0: 0x000000000000ee00
->  0xee00: lbz    8, 0(3)
    0xee04: rldicr 10, 3, 0, 61
    0xee08: mr     11, 3
    0xee0c: lis    5, -258
(lldb) bt
* thread #1, name = 'a.out', stop reason = signal SIGSEGV
  * frame #0: 0x000000000000ee00
(lldb)
```

After fix, for both Live and Coredump:
```
Process 21234150 stopped
* thread #1, name = 'a.out', stop reason = signal SIGSEGV
      frame #0: 0x000000000000ee00 
->  0xee00: lbz    8, 0(3)
    0xee04: rldicr 10, 3, 0, 61
    0xee08: mr     11, 3
    0xee0c: lis    5, -258
(lldb) bt
* thread #1, name = 'a.out', stop reason = signal SIGSEGV
  * frame #0: 0x000000000000ee00 
    frame #1: 0x090000000023b254 libc.a`_doprnt + 16404
    frame #2: 0x0900000000236948 libc.a`printf + 200
    frame #3: 0x0900000003b4b4b0 libg.so`g(a=5, b=1) at g.c:5
    frame #4: 0x0900000003b4a4fc libf.so`f(a=3, b=2) at f.c:8
    frame #5: 0x00000001000008d8 a.out`main at main.c:8
    frame #6: 0x00000001000004ac a.out`__start + 116
```
