### PR TITLE
C++ dynamic type resolution

### DIFF
--- a/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.cpp
+++ b/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.cpp
@@ -404,13 +404,19 @@ void ObjectFileXCOFF::ParseSymtab(Symtab &lldb_symtab) {
           }
 
           // XMC_RO, XMC_RW, and XMC_BS are non-code csects (read-only data
-          // tables, writable data, BSS)
+          // tables, writable data, BSS).
+          //
+          // Exception: vtable csects (Itanium mangled name prefix "_ZTV") are
+          // stored in XMC_RO and must retain their address so that
+          // ItaniumABIRuntime can resolve the vtable pointer to a symbol for
+          // dynamic type detection 
           if (smc == XCOFF::XMC_RO || smc == XCOFF::XMC_RW ||
               smc == XCOFF::XMC_BS) {
-            symbol.GetAddressRef() = Address();
             uint64_t csect_size = csect_aux.getSectionOrLength();
             if (csect_size > 0)
               symbol.SetByteSize(csect_size);
+            if (!symbolName.starts_with("_ZTV"))
+              symbol.GetAddressRef() = Address();
           } else if (smc == XCOFF::XMC_PR) {
             // XMC_PR is a standalone named code csect (not an entry label
             // inside a larger csect).  Set its declared size directly.

--- a/lldb/source/Version/Version.cpp
+++ b/lldb/source/Version/Version.cpp
@@ -11,7 +11,7 @@
 #include "lldb/Version/Version.inc"
 #include "clang/Basic/Version.h"
 
-const char *aix_version_string = " AIX pre-release VRMF: 22.1.7.2 \n";
+const char *aix_version_string = " AIX pre-release VRMF: 22.1.7.3 \n";
 
 static const char *GetLLDBVersion() {
 #ifdef LLDB_FULL_VERSION_STRING


### PR DESCRIPTION
 vtable csects (Itanium mangled name prefix "_ZTV") are
 stored in XMC_RO and must retain their address so that
 ItaniumABIRuntime can resolve the vtable pointer to a symbol for
 dynamic type detection