### PR TITLE
Attach path fix (execv)

### DIFF
--- a/lldb/source/Host/aix/Host.cpp
+++ b/lldb/source/Host/aix/Host.cpp
@@ -111,8 +111,7 @@ static std::string ResolveExecutablePath(llvm::StringRef exe_path,
 
   if (cwd_len > 0) {
     cwd[cwd_len] = '\0';
-    std::string full_path =
-        std::string(cwd) + "/" + exe_path.str();
+    std::string full_path = std::string(cwd) + exe_path.str();
 
     if (realpath(full_path.c_str(), real_path) != nullptr) {
       resolved_path = real_path;

--- a/lldb/source/Host/aix/Host.cpp
+++ b/lldb/source/Host/aix/Host.cpp
@@ -107,11 +107,12 @@ static std::string ResolveExecutablePath(llvm::StringRef exe_path,
 
   // Try to resolve using the process's cwd
   std::string cwd_link = "/proc/" + std::to_string(pid) + "/cwd";
-  ssize_t len = readlink(cwd_link.c_str(), cwd, sizeof(cwd) - 1);
+  ssize_t cwd_len = readlink(cwd_link.c_str(), cwd, sizeof(cwd) - 1);
 
-  if (len > 0) {
-    cwd[len] = '\0';
-    std::string full_path = std::string(cwd) + exe_path.str();
+  if (cwd_len > 0) {
+    cwd[cwd_len] = '\0';
+    std::string full_path =
+        std::string(cwd) + "/" + exe_path.str();
 
     if (realpath(full_path.c_str(), real_path) != nullptr) {
       resolved_path = real_path;
@@ -173,13 +174,23 @@ static bool GetExePathAndIds(::pid_t pid, ProcessInstanceInfo &process_info) {
     return false;
 
   std::memcpy(&psinfoData, PsinfoBuffer->getBufferStart(), sizeof(psinfoData));
+
+  // pr_psargs holds argv[0] + arguments as a single string; take the first
+  // space-delimited token as the executable name.  Fall back to pr_fname (the
+  // short process name, always set by the kernel) when pr_psargs is empty
+  // this can happen for processes created via execv(..., nullptr)
   llvm::StringRef PathRef(
       psinfoData.pr_psargs,
       strnlen(psinfoData.pr_psargs, sizeof(psinfoData.pr_psargs)));
-  if (PathRef.empty())
-    return false;
 
   llvm::StringRef executable = PathRef.split(' ').first;
+  if (executable.empty()) {
+    executable = llvm::StringRef(
+        psinfoData.pr_fname,
+        strnlen(psinfoData.pr_fname, sizeof(psinfoData.pr_fname)));
+  }
+  if (executable.empty())
+    return false;
 
   // Resolve the executable path to an absolute path
   std::string resolved_path = ResolveExecutablePath(executable, pid);

--- a/lldb/source/Version/Version.cpp
+++ b/lldb/source/Version/Version.cpp
@@ -11,7 +11,7 @@
 #include "lldb/Version/Version.inc"
 #include "clang/Basic/Version.h"
 
-const char *aix_version_string = " AIX pre-release VRMF: 22.1.7.4 \n";
+const char *aix_version_string = " AIX pre-release VRMF: 22.1.7.5 \n";
 
 static const char *GetLLDBVersion() {
 #ifdef LLDB_FULL_VERSION_STRING


### PR DESCRIPTION
```
# cat endless.C
 
#include <unistd.h>
#include <errno.h>
#include <iostream>
 
int main(int argc, char** argv) {
  if (2 == argc && 1 == atoi(argv[1])) {
    pid_t child_pid;
    if (!(child_pid = fork())) {
      int rc = execv(argv[0], nullptr);
      {
        char emsg[256];
        sprintf(emsg, "%s: %s", __FUNCTION__, argv[0]);
        perror(emsg);
      }
    }
  }
 
  while (1) {
    sleep(10);
  }
  return 0;
}
 
# ibm-clang++_r -g endless.C -o endless

> ./endless 1 &
[1] 11338168

> ps -fT 11338168
     UID      PID     PPID   C    STIME    TTY  TIME CMD
    root 11338168 16777630   0 11:00:40  pts/1  0:00 ./endless 1
    root 16122268 11338168   0 11:00:40  pts/1  0:00 [endless]

> bin/lldb -p 11338168
(lldb) process attach --pid 11338168
Process 11338168 stopped
* thread #1, name = 'endless', stop reason = signal SIGSTOP
      frame #0: 0xd0596010 libpthreads.a`_p_nsleep + 16
libpthreads.a`_p_nsleep:
->  0xd0596010 <+16>: lwz    2, 20(1)
    0xd0596014 <+20>: lwz    12, 72(1)
    0xd0596018 <+24>: addi   1, 1, 64
    0xd059601c <+28>: mtlr   12
Executable binary set to "/home/dhruv/tests/endless".
Architecture set to: powerpc-ibm-aix7.2.0.0.

lldb -p 17498770
(lldb) process attach --pid 16122268
error: attach failed: Cannot get process architectrue
(lldb) q
```